### PR TITLE
Add scheduling of morning briefings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ npm-debug.log
 /tmp
 /target
 cloudformation.json
+dynamodb.json

--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -59,13 +59,16 @@ Parameters:
         Description: Url of facebook messenger endpoint
         Type: String
         Default: https://graph.facebook.com/v2.6/me/messages
+    DynamodbTableName:
+        Description: Name of dynamodb table used to store user data
+        Type: String
 
 Mappings:
     StageMap:
         PROD:
-            MinSize: 3
-            MaxSize: 6
-            DesiredCapacity: 3
+            MinSize: 1
+            MaxSize: 2
+            DesiredCapacity: 1
             InstanceType: t2.micro
         CODE:
             MinSize: 1
@@ -116,6 +119,32 @@ Resources:
                         - ec2:DescribeInstances
                     Resource:
                         - "*"
+            Roles:
+                - Ref: FacebookNewsBotRole
+
+    DynamoPolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+            PolicyName: dynamo-policy
+            PolicyDocument:
+                Statement:
+                    Effect: Allow
+                    Action:
+                        - dynamodb:GetItem
+                        - dynamodb:PutItem
+                        - dynamodb:UpdateItem
+                        - dynamodb:Query
+                    Resource:
+                        "Fn::Join":
+                            - ""
+                            -
+                                - "arn:aws:dynamodb:"
+                                - Ref: AWS::Region
+                                - ":"
+                                - Ref: AWS::AccountId
+                                - ":table/"
+                                - Ref: DynamodbTableName
+                                - "*"
             Roles:
                 - Ref: FacebookNewsBotRole
 
@@ -384,4 +413,6 @@ Resources:
                                     - Ref: FacebookUrl
                                     - " DEFAULT_IMAGE_URL="
                                     - Ref: DefaultImageUrl
+                                    - " DYNAMODB_TABLE_NAME="
+                                    - Ref: DynamodbTableName
                                     - " pm2 start application.pm2.json"

--- a/cloudformation/dynamodb.yml
+++ b/cloudformation/dynamodb.yml
@@ -1,0 +1,37 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: DynamoDB Tables Template
+Parameters:
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+Resources:
+  facebookNewsBotUsers:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      AttributeDefinitions:
+        - AttributeName: ID
+          AttributeType: S
+        - AttributeName: notificationTimeUTC
+          AttributeType: S
+      KeySchema:
+        - AttributeName: ID
+          KeyType: HASH
+      GlobalSecondaryIndexes:
+        - IndexName: notificationTimeUTC-ID-index
+          KeySchema:
+            - AttributeName: notificationTimeUTC
+              KeyType: HASH
+            - AttributeName: ID
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: '5'
+            WriteCapacityUnits: '1'
+      ProvisionedThroughput:
+        ReadCapacityUnits: '5'
+        WriteCapacityUnits: '1'

--- a/index.js
+++ b/index.js
@@ -1,19 +1,18 @@
 "use strict"
 const Express = require("express")
 const BodyParser = require("body-parser")
-const Request = require('request')
+const Request = require("request")
+const Moment = require("moment")
 const UserStore = new (require("./lib/user-store"))
-const get = require('simple-get-promise').get
-const asJson = require('simple-get-promise').asJson
+const Capi = require("./lib/capi")
+const Facebook = require("./lib/facebook")
+const Schedule = require("node-schedule")
 
 const VERIFY_TOKEN = process.env.VERIFY_TOKEN
 const ACCESS_TOKEN = process.env.ACCESS_TOKEN
-const API_KEY = process.env.API_KEY
 
 const DEFAULT_IMAGE_URL = process.env.DEFAULT_IMAGE_URL
-const FACEBOOK_URL = process.env.FACEBOOK_URL === "" ? "https://graph.facebook.com/v2.6/me/messages" : process.env.FACEBOOK_URL
-
-const CAPI_BASE_URL = "http://content.guardianapis.com/"
+const FACEBOOK_URL = process.env.FACEBOOK_URL === "" ? "https://graph.facebook.com/v2.6" : process.env.FACEBOOK_URL
 const CAMPAIGN_CODE_PARAM = "CMP=fb_newsbot"
 
 const app = Express()
@@ -23,50 +22,52 @@ app.use(BodyParser.json())
 
 const Events = {
   unknown(id) {
-    sendMessage(
+    Facebook.sendMessage(
       id,
       buildButtonsAttachment(
-        "Sorry! I’m pretty stupid at the moment. My creators are training me to understand and do more.",
+        "Sorry, I don't know what you mean.",
         [buildButton("postback", "So, what can you do?", "help")]
       )
     )
   },
   help(id) {
-    sendMessage(
+    sendMenu(
       id,
-      buildMenu("I’m a virtual assistant created by the Guardian to keep you up-to-date with the latest news.\nI can give you the headlines, trending news or deliver a morning digest to you.\nHow can I help you?")
+      "I'm a virtual assistant created by the Guardian to keep you up-to-date with the latest news.\n\nI can give you the headlines, trending news or deliver a morning briefing to you.\nHow can I help you?"
     )
   },
   menu(id) {
-    sendMessage(
+    sendMenu(
       id,
-      buildMenu("How can I help?")
+      "How can I help?"
     )
   },
   start(id) {
-    UserStore.addUser(id)
-    sendMessage(
-      id,
-      buildButtonsAttachment(
-        "Hi there {name}, I’m a virtual assistant created by the Guardian to keep you up-to-date with the latest news.\nCan I deliver you the headlines each morning?",
-        [
-          buildButton("postback", "Yes, that would be great", "subscribe_yes"),
-          buildButton("postback", "No thanks", "subscribe_no")
-        ]
-      )
-    )
-  },
-  greeting(id) {
-    sendMessage(
-      id,
-      buildMenu("Hi there {name}, how can I help you?")
-    )
+    //Is this an existing user?
+    UserStore.getUser(id, (err, data) => {
+      if (err) {
+        console.log("Error looking up user "+ id +": "+ JSON.stringify(err))
+      } else {
+        Facebook.getFacebookUser(id, (err, response, body) => {
+          if (err) {
+            console.log("Error retrieving user "+ id +"from facebook: "+ JSON.stringify(err))
+          } else {
+            const name = JSON.parse(body)["first_name"]
+            if (data.Item) {
+              sendMenu(id, "Hi there "+ name +", how can I help you?")
+            } else {
+              greetNewUser(id, name)
+            }
+          }
+        })
+      }
+    })
   },
   subscribe_yes(id) {
-    sendMessage(
+    Facebook.sendMessage(
       id,
       buildButtonsAttachment(
-        "Great. When would you like it delivered?",
+        "Great. When would you like your morning briefing delivered?",
         [
           buildButton("postback", "6am", "subscribe_6"),
           buildButton("postback", "7am", "subscribe_7"),
@@ -76,59 +77,133 @@ const Events = {
     )
   },
   subscribe_no(id) {
-    sendMessage(
+    sendMenu(
       id,
-      buildMenu("Ok, maybe later then. You can subscribe to the morning briefing at anytime by saying 'subscribe' or asking for 'help'.\nWould you like the headlines or trending news?")
+      "Ok, maybe later then. You can subscribe to the morning briefing at anytime from the menu.\n\nWould you like the headlines or trending news?"
     )
   },
   subscribe(id, time) {
-    UserStore.setNotificationTime(id, time)
-    sendMessage(
+    //Get timezone from FB then update user's dynamo record
+    Facebook.getFacebookUser(id, (error, response, body) => {
+      const timeString = time.format("HH:mm")
+
+      const offset = JSON.parse(body)["timezone"]
+      const timeStringUTC = getUTCTime(time, offset)
+
+      UserStore.setNotificationTime(id, offset, timeString, timeStringUTC, (err, data) => {
+        if (err) {
+          console.log("Error setting notification time for "+ id +": "+ JSON.stringify(err))
+        } else {
+          sendMenu(
+            id,
+            "Fantastic. You can change your subscription at anytime by asking for 'help' or 'menu'.\n\nWould you like the headlines or trending news?"
+          )
+        }
+      })
+    })
+  },
+  manage_subscription(id) {
+    Facebook.sendMessage(
       id,
-      buildMenu("Fantastic. You can change your subscription at anytime by asking for 'help' or 'menu'.\nWould you like the headlines or trending news?")
+      buildButtonsAttachment(
+        "What would you like to change?",
+        [
+          buildButton("postback", "Change time", "subscribe_yes"),
+          buildButton("postback", "Unsubscribe", "unsubscribe"),
+        ]
+      )
+    )
+  },
+  unsubscribe(id) {
+    UserStore.unsubscribe(id, (err, data) => {
+      if (err) {
+        console.log("Error unsubscribing for "+ id +": "+ JSON.stringify(err))
+      } else {
+        Facebook.sendTextMessage(id, "You will no longer receive the daily morning briefing.\n\nIf you ever want to re-subscribe, you can do so from the menu")
+      }
+    })
+  },
+  morningBriefing(id) {
+    Facebook.sendTextMessage(
+      id,
+      "Good morning from the Guardian. Here is the morning briefing:",
+      Events.headlines(id)
     )
   },
   headlines(id) {
-    getEditorsPicks(id)
+    getCapiResults(id, Capi.getEditorsPicks)
   },
   trending(id) {
-    getMostViewed(id)
+    getCapiResults(id, Capi.getMostViewed)
   }
 }
 
-function buildMenu(message) {
-  return buildButtonsAttachment(
-    message,
-    [
-      buildButton("postback", "Headlines", "headlines"),
-      buildButton("postback", "Trending", "trending"),
-      buildButton("postback", "Subscribe to morning digest", "subscribe_yes")  //TODO - only if not subscribed
-    ]
-  )
-}
-
-function sendTextMessage(sender, message, callback) {
-  sendMessage(sender, {text: message}, callback)
-}
-
-function sendMessage(sender, message, callback) {
-  let json = JSON.stringify(message)
-
-  Request({
-    url: FACEBOOK_URL,
-    qs: { access_token: ACCESS_TOKEN},
-    method: 'POST',
-    json: {
-      recipient: { id:sender },
-      message: message
+function greetNewUser(id, name) {
+  UserStore.addUser(id, (err, data) => {
+    if (err) {
+      console.log("Error adding user "+ id +": "+ JSON.stringify(err))
+    } else {
+      Facebook.sendMessage(
+        id,
+        buildButtonsAttachment(
+          "Hi there "+ name+ ", I'm a virtual assistant created by the Guardian to keep you up-to-date with the latest news.\n\nCan I deliver you a daily morning briefing?",
+          [
+            buildButton("postback", "Yes please", "subscribe_yes"),
+            buildButton("postback", "No thanks", "subscribe_no")
+          ]
+        )
+      )
     }
-  }, (error, response, body) => {
-    if (error) {
-      console.log('Error sending message to facebook: ', error);
-    } else if (response.body.error) {
-      console.log('Error: ', response.body.error);
-    } else if (typeof callback !== 'undefined') {
-      callback(error, response, body)
+  })
+}
+
+function localeToFront(locale) {
+  //http://fbdevwiki.com/wiki/Locales
+  if (locale === "en_GB") {
+    return "uk"
+  } else if (locale === "en_US") {
+    return "us"
+  } else if (locale === "en_UD") {
+    return "au"
+  } else {
+    return "international"
+  }
+}
+
+//Returns the time adjusted by the offset as a string
+function getUTCTime(time, offset) {
+  //facebook timezone offset is a float in [-24, 24]
+  const reg = offset.toString().match(/^([0-9]*)(\.[0-9]*)?$/)
+  const hours = reg[1]
+  const mins = (typeof reg[2] !== "undefined") ? parseFloat(reg[2]) * 60 : 0
+  const timeUTC = time.subtract(hours, "hours").subtract(mins, "minutes")
+  return timeUTC.format("HH:mm")
+}
+
+function sendMenu(id, message) {
+  UserStore.getUser(id, (err, data) => {
+    if (err) {
+      console.log("Error looking up user "+ id +": "+ JSON.stringify(err))
+    } else {
+      const getSubButton = (isSubscribed) => {
+        if (isSubscribed) {
+          return buildButton("postback", "Manage subscription", "manage_subscription")
+        } else {
+          return buildButton("postback", "Subscribe", "subscribe_yes")
+        }
+      }
+
+      Facebook.sendMessage(
+        id,
+        buildButtonsAttachment(
+          message,
+          [
+            buildButton("postback", "Headlines", "headlines"),
+            buildButton("postback", "Trending", "trending"),
+            getSubButton(data.Item.notificationTime !== "-")
+          ]
+        )
+      )
     }
   })
 }
@@ -182,66 +257,107 @@ function buildGenericAttachment(elements) {
   }
 }
 
-function getEditorsPicks(id) {
-  doCapiQuery(id, "editors-picks")
+function getCapiResults(id, callback) {
+  Facebook.getFacebookUser(id, (error, response, body) => {
+    if (error) {
+      console.log("Error getting facebook user "+ id +": "+ JSON.stringify(error))
+    } else {
+      const front = localeToFront(JSON.parse(body)["locale"])
+      callback(id, front, sendCapiResults)
+    }
+  })
 }
 
-function getMostViewed(id) {
-  doCapiQuery(id, "most-viewed")
-}
+function sendCapiResults(id, results) {
+  const elements = results.slice(0,5).map(item => {
+    return buildElement(
+      item.webTitle,
+      item.fields.standfirst.replace(/<.*?>/g, ""),
+      getImageUrl(item),
+      [buildLinkButton(item.webUrl)]
+    )
+  })
 
-function doCapiQuery(id, type) {
-  const url = CAPI_BASE_URL + "uk-news?page-size=0&show-"+ type +"=true&show-elements=image&show-fields=standfirst,thumbnail&api-key="+ API_KEY
-  console.log("Requesting: "+ url)
-
-  get(url)
-    .then(asJson)
-    .then(json => {
-
-      const fieldName = type === "editors-picks" ? "editorsPicks" : "mostViewed"
-      const elements = json.response[fieldName].slice(0,4).map(item => {
-        return buildElement(
-          item.webTitle,
-          item.fields.standfirst.replace(/<.*?>/g, ""),
-          getImageUrl(item),
-          [buildLinkButton(item.webUrl)]
-        )
-      })
-
-      sendMessage(id, buildGenericAttachment(elements))
-    })
-    .catch(error => { console.log("CAPI error: "+ error) })
+  Facebook.sendMessage(id, buildGenericAttachment(elements))
 }
 
 // Look for image with width 1000, otherwise the next widest
 function getImageUrl(item) {
   let imageUrl = DEFAULT_IMAGE_URL
-  let widest = 0
   if ("elements" in item) {
-    let element = getMainElement(item.elements)
+    const element = getMainElement(item.elements)
     if (typeof element !== "undefined") {
       if ("assets" in element && element.assets.length > 0) {
-        for (let assetIdx in element.assets) {
-          let asset = element.assets[assetIdx]
-          let width = parseInt(asset.typeData.width)
+        element.assets.reduce((widest, asset) => {
+          const width = parseInt(asset.typeData.width)
           if (width <= 1000 && width > widest) {
             imageUrl = asset.file
-            widest = width
-            if (width === 1000) {
-              break
-            }
+            return width
+          } else {
+            return widest
           }
-        }
+        }, 0)
       }
     }
   }
   return imageUrl
 }
+
 function getMainElement(elements) {
-  return elements.find(element => {
+  const mainElement = elements.find(element => {
     return ("relation" in element && element.relation === "main")
   })
+  if (typeof mainElement !== "undefined") {
+    return mainElement
+  } else {
+    return elements[0]
+  }
 }
+
+/*
+ *  Every 15 mins (the smallest interval between timezones), query the dynamo table
+ *  for users with a notificationTimeUTC equal to current UTC time, and push to them.
+ *  Also check if their timezone has changed since the user was last handled, and
+ *  update if so.
+ */
+const recRule = new Schedule.RecurrenceRule()
+recRule.minute = [0, 15, 30, 45]
+Schedule.scheduleJob(recRule, () => {
+  const now = Moment.utc().format("HH:mm")
+  console.log("Looking for users with time: " + now)
+
+  UserStore.notifyUsers(now, (err, data) => {
+    if (err) {
+      console.log("Error querying users: "+ err)
+    } else {
+      console.log("Found "+ data.Items.length +" users")
+      data.Items.forEach(user => {
+        Facebook.getFacebookUser(user.ID, (error, response, body) => {
+
+          const latestOffset = JSON.parse(body)["timezone"]
+          if (latestOffset === user.offsetHours) {
+            Events.morningBriefing(user.ID)
+          } else {
+            //User's timezone has changed
+            if (latestOffset < user.offsetHours) {
+              //We've missed the notification time for this new timezone, so push now
+              Events.morningBriefing(user.ID)
+            }
+
+            const timeStringUTC = getUTCTime(Moment(user.notificationTime, "HH:mm"), latestOffset)
+            UserStore.setNotificationTime(user.ID, latestOffset, user.notificationTime, timeStringUTC, (err, data) => {
+              if (err) {
+                console.log("Error setting notification time for "+ id +": "+ JSON.stringify(err))
+              } else {
+                console.log("Updated user's settings: "+ id)
+              }
+            })
+          }
+        })
+      })
+    }
+  })
+})
 
 // Verification GET
 app.get("/webhook/", (req, res) => {
@@ -266,34 +382,39 @@ app.post("/webhook/", (req, res) => {
 
     if (event.message && event.message.text) {
       const text = event.message.text.trim().toLowerCase()
-      console.log("message: "+ text)
+      console.log("Received message: '"+ text +"', from user "+ id)
 
       if (text.match(/^(hi|hello|ola|hey|salut)\s*[!?.]*$/)) {
-        if (UserStore.userExists(id)) {
-          Events.greeting(id)
-        } else {
-          Events.start(id)
-        }
-      } else if (text.match(/^help *|^what can you do */)) {
-        Events["help"](id)
-      } else if (text.match(/^menu */)) {
-        Events["menu"](id)
+        Events.start(id)
+      } else if (text.match(/^help|^what can you do/)) {
+        Events.help(id)
+      } else if (text.match(/^menu/)) {
+        Events.menu(id)
+      } else if (text.match(/^subscribe/)) {
+        Events.subscribe_yes(id)
+      } else if (text.match(/^unsubscribe/)) {
+        Events.unsubscribe(id)
+      } else if (text.includes("headlines")) {
+        Events.headlines(id)
+      } else if (text.includes("trending")) {
+        Events.trending(id)
       } else {
-        Events["unknown"](id)
+        Events.unknown(id)
       }
 
     } else if (event.postback) {
       const data = event.postback.payload
-      console.log("postback: "+ data)
+      console.log("Received payload: '"+ data +"', from user "+ id)
+
       if (Events[data]) {
         Events[data](id)
       } else {
         //Have we received a subscription?
         const matches = data.match(/^subscribe_([0-9])$/)
         if (matches.length > 1) {
-          Events["subscribe"](id, matches[1])
+          Events.subscribe(id, Moment(matches[1], "HH"))
         } else {
-          Events["unknown"](id)
+          Events.unknown(id)
         }
       }
     }

--- a/lib/capi.js
+++ b/lib/capi.js
@@ -1,0 +1,37 @@
+"use strict"
+
+module.exports = {
+  getEditorsPicks,
+  getMostViewed
+}
+
+const get = require('simple-get-promise').get
+const asJson = require('simple-get-promise').asJson
+
+const API_KEY = process.env.API_KEY
+const CAPI_BASE_URL = "http://content.guardianapis.com/"
+
+function getEditorsPicks(id, front, callback) {
+  doCapiQuery(id, "editors-picks", front, callback)
+}
+
+function getMostViewed(id, front, callback) {
+  doCapiQuery(id, "most-viewed", front, callback)
+}
+
+function doCapiQuery(id, type, front, callback) {
+  const url = CAPI_BASE_URL + 
+              front + 
+              "?page-size=0&show-"+ type +"=true"+
+              "&show-elements=image&show-fields=standfirst,thumbnail"+
+              "&api-key="+ API_KEY
+  
+  get(url)
+    .then(asJson)
+    .then(json => {
+      const fieldName = type === "editors-picks" ? "editorsPicks" : "mostViewed"
+      callback(id, json.response[fieldName])
+    })
+    .catch(error => { console.log("CAPI error: "+ error) })
+}
+

--- a/lib/facebook.js
+++ b/lib/facebook.js
@@ -1,0 +1,54 @@
+"use strict"
+
+module.exports = {
+  sendTextMessage,
+  sendMessage,
+  getFacebookUser
+}
+
+const Request = require("request")
+
+const FACEBOOK_URL = process.env.FACEBOOK_URL === "" ? "https://graph.facebook.com/v2.6" : process.env.FACEBOOK_URL
+const ACCESS_TOKEN = process.env.ACCESS_TOKEN
+
+function sendTextMessage(sender, message, callback) {
+  sendMessage(sender, {text: message}, callback)
+}
+
+function sendMessage(sender, message, callback) {
+  const json = JSON.stringify(message)
+
+  Request({
+    url: FACEBOOK_URL + "/me/messages",
+    qs: { access_token: ACCESS_TOKEN },
+    method: 'POST',
+    json: {
+      recipient: { id:sender },
+      message: message
+    }
+  }, (error, response, body) => {
+    if (error) {
+      console.log('Error sending message to facebook: ', error)
+    } else if (response.body.error) {
+      console.log('Error: ', response.body.error)
+    } else if (typeof callback !== 'undefined') {
+      callback(error, response, body)
+    }
+  })
+}
+
+function getFacebookUser(id, callback) {
+  const url = FACEBOOK_URL + "/" + id
+  Request({
+    url: url,
+    qs: { access_token: ACCESS_TOKEN },
+    method: "GET"
+  }, (error, response, body) => {
+    if (error) {
+      console.log("Error getting user data from facebook: ", error)
+    } else {
+      callback(error, response, body)
+    }
+  })
+}
+

--- a/lib/user-store.js
+++ b/lib/user-store.js
@@ -1,24 +1,77 @@
 "use strict"
 
+const AWS = require("aws-sdk")
+
+const TABLE_NAME = process.env.DYNAMODB_TABLE_NAME
+
+AWS.config.update({
+  region: 'eu-west-1'
+})
+
 module.exports = UserStore
 
 function UserStore() {
-  //TODO - dynamodb
-  this._users = {}
+  this._docClient = new AWS.DynamoDB.DocumentClient()
 }
 
-UserStore.prototype.userExists = function(id) {
-  if (id in this._users) {
-    return true
-  } else {
-    return false
-  }
+UserStore.prototype.getUser = function(id, callback) {
+  this._docClient.get({
+    TableName: TABLE_NAME,
+    Key: {
+      "ID": id
+    }
+  }, callback)
 }
 
-UserStore.prototype.addUser = function(id) {
-  this._users[id] = 1
+UserStore.prototype.addUser = function(id, callback) {
+  this._docClient.put({
+    TableName: TABLE_NAME,
+    Item: {
+      "ID": id,
+      "offsetHours": 0,
+      "notificationTime": "-",
+      "notificationTimeUTC": "-"
+    }
+  }, callback)
 }
 
-UserStore.prototype.setNotificationTime = function(id, time) {
-  this._users[id] = time
+UserStore.prototype.setNotificationTime = function(id, offset, time, timeUTC, callback) {
+  this._docClient.update({
+    TableName: TABLE_NAME,
+    Key: {
+      "ID": id
+    },
+    UpdateExpression: "set notificationTimeUTC = :tUTC, notificationTime = :t, offsetHours = :o",
+    ExpressionAttributeValues: {
+      ":t": time,
+      ":tUTC": timeUTC,
+      ":o": offset
+    }
+  }, callback)
 }
+
+UserStore.prototype.notifyUsers = function(time, callback) {
+  this._docClient.query({
+    TableName: TABLE_NAME,
+    IndexName: "notificationTimeUTC-ID-index",
+    KeyConditionExpression: "notificationTimeUTC = :t",
+    ExpressionAttributeValues: {
+      ":t": time
+    },
+  }, callback)
+}
+
+UserStore.prototype.unsubscribe = function(id, callback) {
+  this._docClient.update({
+    TableName: TABLE_NAME,
+    Key: {
+      "ID": id
+    },
+    UpdateExpression: "set notificationTimeUTC = :tUTC, notificationTime = :t",
+    ExpressionAttributeValues: {
+      ":t": "-",
+      ":tUTC": "-"
+    }
+  }, callback)
+}
+

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "gulp-yaml": "^1.0.1",
     "node-riffraff-artefact": "^1.7.2",
     "request": "^2.72.0",
-    "simple-get-promise": "^1.0.2"
+    "simple-get-promise": "^1.0.2",
+    "aws-sdk": "^2.5.1",
+    "moment": "^2.13.0",
+    "node-schedule": "^1.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
(and various improvements)

- The bot will push a morning briefing (a set of 5 links) to a user at a time specified by them (restricted to 6, 7 or 8am).
- The user's ID and preferences are stored in a dynamodb table.
- It takes the user's current timezone offset from facebook to calculate the correct time to push.
- At intervals of 15 mins, it checks for users in the dynamo table with the current time (all done in UTC). It checks at this point to see if the user's timezone has changed.

The user can request headlines (editors-picks) or trending (most-viewed) at any time. The front (uk/us/au/international) is determined using the facebook user's locale.