### PR TITLE
Make edition configurable

### DIFF
--- a/lib/user-store.js
+++ b/lib/user-store.js
@@ -23,14 +23,15 @@ UserStore.prototype.getUser = function(id, callback) {
   }, callback)
 }
 
-UserStore.prototype.addUser = function(id, callback) {
+UserStore.prototype.addUser = function(id, front, callback) {
   this._docClient.put({
     TableName: TABLE_NAME,
     Item: {
       "ID": id,
       "offsetHours": 0,
       "notificationTime": "-",
-      "notificationTimeUTC": "-"
+      "notificationTimeUTC": "-",
+      "front": front
     }
   }, callback)
 }
@@ -46,6 +47,19 @@ UserStore.prototype.setNotificationTime = function(id, offset, time, timeUTC, ca
       ":t": time,
       ":tUTC": timeUTC,
       ":o": offset
+    }
+  }, callback)
+}
+
+UserStore.prototype.setFront = function(id, front, callback) {
+  this._docClient.update({
+    TableName: TABLE_NAME,
+    Key: {
+      "ID": id
+    },
+    UpdateExpression: "set front = :f",
+    ExpressionAttributeValues: {
+      ":f": front
     }
   }, callback)
 }


### PR DESCRIPTION
We decide which front to use by checking the user's facebook locale string (e.g. "en_GB" => "uk")
It appears this never changes, so e.g. a British person who moved to the US still has "en_GB" (which makes sense).
We'll still use this as a default for now, but the user can now change it by clicking "Change edition". The options are presented as a carousel (like with the headlines), because you're only allowed a max of 3 buttons. In future we could add images for each tile in the carousel.

Note - we have plans to add bots to the US and AU facebook pages as well. The default edition can then be specific to the facebook page.

<img width="628" alt="picture 2" src="https://cloud.githubusercontent.com/assets/1513454/17924607/3d635842-69e1-11e6-80f3-3398d4ec0678.png">
