### PR TITLE
Always lookup user in dynamo

### DIFF
--- a/index.js
+++ b/index.js
@@ -526,7 +526,16 @@ function handleExistingUser(id, event, userData) {
     log(id, "postback", payload.event, {"payload": payload})
 
     if (Events[payload.event]) {
-      Events[payload.event](userData, payload)
+      if (payload.event === "start") {
+        /*
+         * This shouldn't generally happen, but it's possible for an existing
+         * user to get the 'Get started' button in a web browser if they
+         * delete the conversation first.
+         */
+        Events.greeting(userData)
+      } else {
+        Events[payload.event](userData, payload)
+      }
     } else {
       Events.unknown(userData)
     }

--- a/index.js
+++ b/index.js
@@ -330,7 +330,7 @@ function buildGenericAttachment(elements) {
 }
 
 function getAndSendCapiResults(user, type, page) {
-  const sendCapiResults = (id, results) => {
+  const sendCapiResults = (results) => {
     const elements = results.slice(page,page+LINK_COUNT).map(item => {
       return buildElement(
         item.webTitle,
@@ -348,7 +348,7 @@ function getAndSendCapiResults(user, type, page) {
       )
     ]
 
-    Facebook.sendMessage(id, att)
+    Facebook.sendMessage(user.ID, att)
   }
 
   if (type === "headlines") {

--- a/lib/capi.js
+++ b/lib/capi.js
@@ -30,7 +30,7 @@ function doCapiQuery(id, type, front, callback) {
     .then(asJson)
     .then(json => {
       const fieldName = type === "editors-picks" ? "editorsPicks" : "mostViewed"
-      callback(id, json.response[fieldName])
+      callback(json.response[fieldName])
     })
     .catch(error => { console.log("CAPI error: "+ error) })
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -33,7 +33,7 @@ const Messages = {
     "No problem, maybe later then. You can subscribe to the morning briefing at anytime from the menu.\n\nWould you like the headlines or the most popular stories?"
   ]),
   subscribed: randomiser([
-    "Done. You will start to receiving the morning briefing.\n\nRemember, you can change your subscription to this at anytime from the menu. Would you like to see the headlines or the most popular stories right now?"
+    "Done. You will start receiving the morning briefing.\n\nRemember, you can change your subscription to this at anytime from the menu. Would you like to see the headlines or the most popular stories right now?"
   ]),
   unsubscribed: randomiser([
     "Done. You will no longer receive the morning briefing.\n\nYou can re-subscribe at anytime from the menu"

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -29,7 +29,7 @@ const Messages = {
   subscribe_yes: randomiser([
     "Great. When would you like your morning briefing delivered?"
   ]),
-  susbcribe_no: randomiser([
+  subscribe_no: randomiser([
     "No problem, maybe later then. You can subscribe to the morning briefing at anytime from the menu.\n\nWould you like the headlines or the most popular stories?"
   ]),
   subscribed: randomiser([


### PR DESCRIPTION
New users should first be presented with a 'Get started' button (this is a standard facebook messenger thing - https://developers.facebook.com/docs/messenger-platform/thread-settings/get-started-button).
This triggers the `start` event, which adds the user to dynamodb and greets them.

However, the Get started button keeps disappearing from facebook messenger (@chriswilk has asked facebook to sort this out). We should defend against this by always looking up the user in dynamo whenever a message is received from facebook. So even if they haven't arrived via the Get started button, we'll add them to dynamo and send the initial greeting.