### PR TITLE
Fix initial menu for new users

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,7 @@ const Events = {
           if (err) {
             console.log("Error setting notification time for "+ user.ID +": "+ JSON.stringify(err))
           } else {
+            user.notificationTime = timeString
             sendMenu(
               user,
               Messages.subscribed()
@@ -493,6 +494,7 @@ app.post("/webhook/", (req, res) => {
            * unreliable. Either way, let's give them the initial greeting and add them to
            * dynamodb.
            */
+          log(id, "postback", "start", {})
           Events.start({"ID": id})
         }
       }


### PR DESCRIPTION
Immediately after a new user subscribes for the first time, a menu button incorrectly says "Subscribe" rather than "Manage subscription". This fixes that.

(also added logging for the `start` event)