### PR TITLE
Use item_url on elements and add 'share' button

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,7 +342,7 @@ function getAndSendCapiResults(user, type, page) {
       return buildElement(
         item.webTitle, [
           buildButton("postback", "Share", buildPayload("share", {
-            "url": item.webUrl,
+            "url": item.webUrl + "?"+ CAMPAIGN_CODE_PARAM +"_share",
             "title": item.webTitle
           }))
         ],

--- a/index.js
+++ b/index.js
@@ -174,6 +174,9 @@ const Events = {
   most_popular(user, payload) {
     const page = (payload && payload.page) ? payload.page : 0
     getAndSendCapiResults(user, "most_popular", page)
+  },
+  share(user, payload) {
+    Facebook.sendTextMessage(user.ID, payload.title +" - "+ payload.url)
   }
 }
 
@@ -337,8 +340,12 @@ function getAndSendCapiResults(user, type, page) {
   const sendCapiResults = (results) => {
     const elements = results.slice(page,page+LINK_COUNT).map(item => {
       return buildElement(
-        item.webTitle,
-        [buildLinkButton(item.webUrl)],
+        item.webTitle, [
+          buildButton("postback", "Share", buildPayload("share", {
+            "url": item.webUrl,
+            "title": item.webTitle
+          }))
+        ],
         item.fields.standfirst.replace(/<.*?>/g, ""),
         getImageUrl(item),
         item.webUrl

--- a/index.js
+++ b/index.js
@@ -289,7 +289,7 @@ function buildQuickReply(title, payload) {
   }
 }
 
-function buildElement(title, buttons, subtitle, imageUrl) {
+function buildElement(title, buttons, subtitle, imageUrl, itemUrl) {
   let element = {
     "title": title
   }
@@ -301,6 +301,9 @@ function buildElement(title, buttons, subtitle, imageUrl) {
   }
   if (typeof imageUrl !== "undefined") {
     element.image_url = imageUrl
+  }
+  if (typeof itemUrl !== "undefined") {
+    element.item_url = itemUrl
   }
   return element
 }
@@ -337,7 +340,8 @@ function getAndSendCapiResults(user, type, page) {
         item.webTitle,
         [buildLinkButton(item.webUrl)],
         item.fields.standfirst.replace(/<.*?>/g, ""),
-        getImageUrl(item)
+        getImageUrl(item),
+        item.webUrl
       )
     })
 


### PR DESCRIPTION
### item_url
Setting this turns each tile on the carousel into a link, which will open in Instant Articles if available there. This means we can remove the "Read story" button.

### Share button
This is a bit of a hack, since FB doesn't provide a way of sharing links from the carousel. A "Share" button appears below each tile, and when clicked we send a link to the article as a text message. Messenger automatically accompanies that link with a share button, allowing the user to share on Messenger only.
The URL has the campaign code `fb_newsbot_share`.