### PR TITLE
Cache capi results

### DIFF
--- a/lib/capi.js
+++ b/lib/capi.js
@@ -19,9 +19,9 @@ function Cache() {
   this._data = {}
 }
 Cache.prototype.get = function(url) {
-  const data = this._data[url]
-  if (typeof data !== "undefined" && Moment.utc().diff(data.timestamp) < data.staleMs) {
-      return this._data[url]
+  const item = this._data[url]
+  if (typeof item !== "undefined" && Moment.utc().diff(item.timestamp) < item.staleMs) {
+      return item.data
   } else {
       return null
   }
@@ -51,7 +51,7 @@ function doCapiQuery(id, type, front, callback) {
 
   const cached = CACHE.get(url)
   if (cached !== null) {
-    callback(cached.data)
+    callback(cached)
   } else {
     get(url)
       .then(asJson)

--- a/lib/capi.js
+++ b/lib/capi.js
@@ -19,12 +19,18 @@ function Cache() {
   this._data = {}
 }
 Cache.prototype.get = function(url) {
-  return this._data[url]
+  const data = this._data[url]
+  if (typeof data !== "undefined" && Moment.utc().diff(data.timestamp) < data.staleMs) {
+      return this._data[url]
+  } else {
+      return null
+  }
 }
-Cache.prototype.put = function(url, data) {
+Cache.prototype.put = function(url, data, staleMs) {
   this._data[url] = {
     "timestamp": Moment.utc(),
-    "data": data
+    "data": data,
+    "staleMs": staleMs
   }
 }
 
@@ -44,7 +50,7 @@ function doCapiQuery(id, type, front, callback) {
               "&api-key="+ API_KEY
 
   const cached = CACHE.get(url)
-  if (typeof cached !== "undefined" && Moment.utc().diff(cached.timestamp) < CACHE_STALE_MILLISECONDS) {
+  if (cached !== null) {
     callback(cached.data)
   } else {
     get(url)
@@ -52,7 +58,7 @@ function doCapiQuery(id, type, front, callback) {
       .then(json => {
         const fieldName = getFieldName(type)
         const data = json.response[fieldName]
-        CACHE.put(url, data)
+        CACHE.put(url, data, CACHE_STALE_MILLISECONDS)
         callback(data)
       })
       .catch(error => { console.log("CAPI error: "+ error) })

--- a/lib/capi.js
+++ b/lib/capi.js
@@ -7,9 +7,26 @@ module.exports = {
 
 const get = require('simple-get-promise').get
 const asJson = require('simple-get-promise').asJson
+const Moment = require("moment")
 
 const API_KEY = process.env.API_KEY
 const CAPI_BASE_URL = "http://content.guardianapis.com/"
+
+const CACHE_STALE_MILLISECONDS = 30000
+const CACHE = new Cache()
+
+function Cache() {
+  this._data = {}
+}
+Cache.prototype.get = function(url) {
+  return this._data[url]
+}
+Cache.prototype.put = function(url, data) {
+  this._data[url] = {
+    "timestamp": Moment.utc(),
+    "data": data
+  }
+}
 
 function getEditorsPicks(id, front, callback) {
   doCapiQuery(id, "editors-picks", front, callback)
@@ -25,13 +42,24 @@ function doCapiQuery(id, type, front, callback) {
               "?page-size=0&show-"+ type +"=true"+
               "&show-elements=image&show-fields=standfirst,thumbnail"+
               "&api-key="+ API_KEY
-  
-  get(url)
-    .then(asJson)
-    .then(json => {
-      const fieldName = type === "editors-picks" ? "editorsPicks" : "mostViewed"
-      callback(json.response[fieldName])
-    })
-    .catch(error => { console.log("CAPI error: "+ error) })
+
+  const cached = CACHE.get(url)
+  if (typeof cached !== "undefined" && Moment.utc().diff(cached.timestamp) < CACHE_STALE_MILLISECONDS) {
+    callback(cached.data)
+  } else {
+    get(url)
+      .then(asJson)
+      .then(json => {
+        const fieldName = getFieldName(type)
+        const data = json.response[fieldName]
+        CACHE.put(url, data)
+        callback(data)
+      })
+      .catch(error => { console.log("CAPI error: "+ error) })
+  }
+}
+
+function getFieldName(type) {
+  return type === "editors-picks" ? "editorsPicks" : "mostViewed"
 }
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "simple-get-promise": "^1.0.2",
     "aws-sdk": "^2.5.1",
     "moment": "^2.13.0",
-    "node-schedule": "^1.1.1"
+    "node-schedule": "^1.1.1",
+    "promise": "^7.1.1"
   },
   "devDependencies": {},
   "scripts": {


### PR DESCRIPTION
Currently the app sends a CAPI request every time it needs the editors-picks or most-viewed. This is not at all scalable, especially in the case of the morning briefing.

Cached results are considered fresh for 30 seconds.