### PR TITLE
Fix handling of missing timezone in facebook response

### DIFF
--- a/index.js
+++ b/index.js
@@ -464,7 +464,9 @@ function notifyUser(dynamoData, fbData) {
       })
     }
   } else {
-    console.log("No timezone found in facebook response: "+ JSON.stringify(response))
+    console.log("No timezone found in facebook response: "+ JSON.stringify(fbData))
+    //It appears sometimes FB doesn't give us a timezone, just push now
+    Events.morningBriefing(dynamoData)
   }
 }
 


### PR DESCRIPTION
This caused people to miss their morning briefings this morning :(
Before sending a morning briefing, it checks if the user's timezone has changed (according to facebook). It turns out sometimes this field is missing in the facebook response - if this happens it now just pushes the morning briefing anyway.

This is a good reason for switching to scalajs - the bug is the result of an incorrect variable name in an error-handling branch after refactoring!