### PR TITLE
Morning briefing

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,8 +15,10 @@ resolvers += Resolver.bintrayRepo("hseeberger", "maven")
 enablePlugins(RiffRaffArtifact, JavaAppPackaging)
 
 val CapiVersion = "10.5"
+val AwsVersion = "1.11.8"
 
 libraryDependencies ++= Seq(
+  "com.google.guava" % "guava" % "19.0",
   "joda-time" % "joda-time" % "2.9.4",
   "org.joda" % "joda-convert" % "1.8.1",
   "org.jsoup" % "jsoup" % "1.8.1",
@@ -35,8 +37,9 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-http-spray-json-experimental" % akkaVersion,
   "com.github.ben-manes.caffeine" % "caffeine" % "2.3.3",
   "de.heikoseeberger" %% "akka-http-circe" % "1.10.0",
-  "com.amazonaws" % "aws-java-sdk-dynamodb" % "1.10.51",
-  "com.amazonaws" % "aws-java-sdk-ec2" % "1.10.52",
+  "com.amazonaws" % "aws-java-sdk-sqs" % AwsVersion,
+  "com.amazonaws" % "aws-java-sdk-dynamodb" % AwsVersion,
+  "com.amazonaws" % "aws-java-sdk-ec2" % AwsVersion,
   "com.gu" %% "scanamo" % "0.7.0",
   "com.typesafe.akka" %% "akka-http-testkit" % akkaVersion,
   "org.scalatest" %% "scalatest" % "3.0.0" % "test",

--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -45,6 +45,9 @@ Parameters:
     DynamodbTableName:
         Description: Name of dynamodb table used to store user data
         Type: String
+    MorningBriefingSnsTopicArn:
+        Description: ARN of the morning briefings SNS topic
+        Type: String
 
 Mappings:
     StageMap:
@@ -163,6 +166,39 @@ Resources:
                           !Sub arn:aws:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${LoggingKinesisStream}
             Roles:
                 - !Ref FacebookNewsBotRole
+
+    SQSPolicy:
+        Type: AWS::IAM::Policy
+        Properties:
+            PolicyName: sqs-policy
+            PolicyDocument:
+                Statement:
+                    - Effect: Allow
+                      Action:
+                          - sqs:ReceiveMessage
+                          - sqs:DeleteMessage
+                          - sqs:DeleteMessageBatch
+                      Resource:
+                          - !GetAtt MorningBriefingSQS.Arn
+            Roles:
+                - !Ref FacebookNewsBotRole
+
+    MorningBriefingSQSPolicy:
+        Type: AWS::SQS::QueuePolicy
+        Properties:
+            Queues:
+                - !Ref MorningBriefingSQS
+            PolicyDocument:
+                Statement:
+                    - Sid: allow-sqs-sendmessage
+                      Effect: Allow
+                      Principal:
+                          AWS: "*"
+                      Action: SQS:SendMessage
+                      Resource: !GetAtt MorningBriefingSQS.Arn
+                      Condition:
+                          ArnEquals:
+                              aws:SourceArn: !Ref MorningBriefingSnsTopicArn
 
     InstanceProfile:
         Type: AWS::IAM::InstanceProfile
@@ -301,6 +337,11 @@ Resources:
                   Value:
                     Ref: App
                   PropagateAtLaunch: true
+
+    MorningBriefingSQS:
+        Type: AWS::SQS::Queue
+        Properties:
+            QueueName: !Sub facebook-news-bot-morning-briefing-${Stage}
 
     LaunchConfiguration:
         Type: AWS::AutoScaling::LaunchConfiguration

--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -30,6 +30,8 @@ object BotConfig {
       new ProfileCredentialsProvider(),
       new InstanceProfileCredentialsProvider()
     )
+
+    val morningBriefingSQSName = getMandatoryString("aws.sqs.morningBriefingSQSName")
   }
 
   object facebook {

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -8,6 +8,7 @@ import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import com.gu.cm.Mode
+import com.gu.facebook_news_bot.briefing.MorningBriefingPoller
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook}
 import com.gu.facebook_news_bot.services.{Capi, CapiImpl, Facebook, FacebookImpl}
 import de.heikoseeberger.akkahttpcirce.CirceSupport
@@ -109,6 +110,8 @@ object Bot extends App with BotService {
       new AmazonDynamoDBAsyncClient(BotConfig.aws.CredentialsProvider).withRegion(awsRegion)
     }
   }
+
+  val poller = system.actorOf(MorningBriefingPoller.props(userStore, capi, facebook))
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)
 }

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
@@ -1,0 +1,142 @@
+package com.gu.facebook_news_bot.briefing
+
+import java.util.concurrent.Executors
+
+import akka.actor.{Actor, Props}
+import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
+import com.amazonaws.services.sqs.model.{DeleteMessageBatchRequest, DeleteMessageBatchRequestEntry, Message, ReceiveMessageRequest}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.briefing.MorningBriefingPoller.Poll
+import com.gu.facebook_news_bot.models.{MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook, SQS, SQSMessageBody}
+import com.gu.facebook_news_bot.state.MainState
+import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText}
+import com.typesafe.scalalogging.StrictLogging
+import io.circe.generic.auto._
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+object MorningBriefingPoller {
+  def props(userStore: UserStore, capi: Capi, facebook: Facebook) = Props(new MorningBriefingPoller(userStore, capi, facebook))
+
+  case object Poll
+}
+
+class MorningBriefingPoller(userStore: UserStore, capi: Capi, facebook: Facebook) extends Actor with StrictLogging {
+
+  private val MaxBatchSize = 10 //Max allowed by SQS
+  private val PollPeriod = 500.millis
+
+  implicit val exec = ExecutionContext.fromExecutorService(
+    Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("morning-briefing-poller-%d").build())
+  )
+
+  override def preStart(): Unit = self ! Poll
+
+  def receive = {
+    case Poll =>
+
+      val request = new ReceiveMessageRequest(BotConfig.aws.morningBriefingSQSName)
+        .withMaxNumberOfMessages(MaxBatchSize)
+        .withWaitTimeSeconds(10)
+
+      val messages: Seq[Message] = Try(SQS.client.receiveMessage(request)) match {
+        case Success(result) => result.getMessages.asScala
+        case Failure(e) =>
+          logger.error(s"Error polling SQS queue: $e")
+          Nil
+      }
+
+      val decodedMessages = messages.flatMap(message => JsonHelpers.decodeJson[SQSMessageBody](message.getBody))
+      decodedMessages.foreach { decodedMessage =>
+        JsonHelpers.decodeJson[User](decodedMessage.Message) foreach processUser
+      }
+
+      //Delete items from the queue
+      if (messages.nonEmpty) {
+        val deleteRequest = new DeleteMessageBatchRequest(
+          BotConfig.aws.morningBriefingSQSName,
+          messages.map(message => new DeleteMessageBatchRequestEntry(message.getMessageId, message.getReceiptHandle)).asJava
+        )
+        Try(SQS.client.deleteMessageBatch(deleteRequest)) recover {
+          case e => logger.warn(s"Failed to delete messages from queue: ${e.getMessage}")
+        }
+      }
+
+      context.system.scheduler.scheduleOnce(PollPeriod, self, Poll)
+
+    case _ =>
+      logger.warn("Unknown message received by MorningBriefingPoller")
+  }
+
+  private def processUser(user: User): Unit = {
+    facebook.getUser(user.ID) map { fbUser =>
+      if (fbUser.timezone == user.offsetHours) {
+        getMorningBriefing(user).onComplete {
+          case Success((updatedUser, fbMessages)) => updateAndSend(updatedUser, fbMessages)
+          case Failure(error) => logger.error(s"Error getting morning briefing for user ${user.ID}: $error")
+        }
+      } else {
+        //User's timezone has changed - fix this now, but don't send briefing
+        val updatedUser = updateNotificationTime(user, fbUser.timezone)
+        updateAndSend(updatedUser, Nil)
+      }
+    }
+  }
+
+  private def updateNotificationTime(user: User, timezone: Double): User = {
+    val notifyTime = DateTime.parse(user.notificationTime, DateTimeFormat.forPattern("HH:mm"))
+    val notifyTimeUTC = notifyTime.minusMinutes((timezone * 60).toInt)
+    user.copy(
+      notificationTimeUTC = notifyTimeUTC.toString("HH:mm"),
+      offsetHours = timezone
+    )
+  }
+
+  private def getMorningBriefing(user: User): Future[Result] = {
+    logger.debug(s"Getting morning briefing for User: $user")
+
+    //TODO - add A/B testing switch here
+    MainState.getHeadlines(user, capi, variant = user.variant)
+  }
+
+  //Update the user in dynamo, then send the messages
+  private def updateAndSend(user: User, messages: List[MessageToFacebook], retry: Int = 0): Unit = {
+    userStore.updateUser(user) map { updateResult =>
+      updateResult.fold(
+        { error: ConditionalCheckFailedException =>
+          //User has since been updated in dynamo, get the latest version and try again
+          if (retry < 3) {
+            userStore.getUser(user.ID) foreach { _.foreach { latestUser =>
+              val mergedUser = user.copy(
+                //All other fields should come from updatedUser
+                version = latestUser.version,
+                front = latestUser.front
+              )
+              updateAndSend(mergedUser, messages, retry+1)
+            }}
+          } else {
+            //Something has gone very wrong
+            logger.error(s"Failed to update user state multiple times. User is $user and error is $error")
+          }
+        }, { _ =>
+          if (messages.nonEmpty) {
+            val briefing = morningMessage(user) :: messages
+            logger.debug(s"Sending morning briefing to ${user.ID}: $briefing")
+            facebook.send(briefing)
+          }
+        }
+      )
+    }
+  }
+
+  private def morningMessage(user: User) = MessageToFacebook.textMessage(user.ID, ResponseText.morningBriefing)
+}

--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -12,4 +12,5 @@ case class User(ID: String,
                 version: Option[Long] = None,
                 contentTopic: Option[String] = None,
                 contentOffset: Option[Int] = None,
-                contentType: Option[String] = None)
+                contentType: Option[String] = None,
+                variant: Option[String] = None)

--- a/src/main/scala/com/gu/facebook_news_bot/services/SQS.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/SQS.scala
@@ -1,0 +1,17 @@
+package com.gu.facebook_news_bot.services
+
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.regions.{Region, Regions}
+import com.amazonaws.services.sqs.AmazonSQSClient
+import com.gu.facebook_news_bot.BotConfig
+
+case class SQSMessageBody(MessageId: String, Message: String)
+
+object SQS {
+  val client = {
+    val sqsClientConfiguration = new ClientConfiguration().withConnectionTimeout(20000).withSocketTimeout(20000)
+    val sqsClient = new AmazonSQSClient(BotConfig.aws.CredentialsProvider, sqsClientConfiguration)
+    sqsClient.setRegion(Region.getRegion(Regions.fromName(BotConfig.aws.region)))
+    sqsClient
+  }
+}

--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -60,6 +60,9 @@ case object MainState extends State {
     result getOrElse State.unknown(user)
   }
 
+  //For use by morning briefing, which for now just uses editors-picks and leaves the user in the MAIN state
+  def getHeadlines(user: User, capi: Capi, variant: Option[String] = None): Future[Result] = carousel(user, HeadlinesType, None, 0, capi, variant)
+
   private def processEvent(user: User, event: Event, capi: Capi, facebook: Facebook): Future[Result] = {
     val result = event match {
       case NewContentEvent(maybeContentType, maybeTopic) =>
@@ -129,10 +132,10 @@ case object MainState extends State {
     )
   }
 
-  private def carousel(user: User, contentType: ContentType, topic: Option[Topic], offset: Int, capi: Capi): Future[Result] = {
+  private def carousel(user: User, contentType: ContentType, topic: Option[Topic], offset: Int, capi: Capi, variant: Option[String] = None): Future[Result] = {
     val futureCarousel = contentType match {
-      case MostViewedType => capi.getMostViewed(user.front, topic) map (contentToCarousel(_, offset))
-      case HeadlinesType => capi.getHeadlines(user.front, topic) map (contentToCarousel(_, offset))
+      case MostViewedType => capi.getMostViewed(user.front, topic) map (contentToCarousel(_, offset, variant))
+      case HeadlinesType => capi.getHeadlines(user.front, topic) map (contentToCarousel(_, offset, variant))
     }
 
     futureCarousel map {

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -10,14 +10,14 @@ object FacebookMessageBuilder {
   val MaxImageWidth = 1000
   val CarouselSize = 5  //Number of items in a carousel
 
-  def contentToCarousel(contentList: Seq[Content], offset: Int): Option[MessageToFacebook.Message] = {
+  def contentToCarousel(contentList: Seq[Content], offset: Int, variant: Option[String] = None): Option[MessageToFacebook.Message] = {
     val sliced = contentList.slice(offset, offset + CarouselSize)
     if (sliced.isEmpty) None
     else {
       val tiles = sliced.map { content =>
         MessageToFacebook.Element(
           title = content.webTitle,
-          item_url = Some(s"${content.webUrl}?CMP=${BotConfig.campaignCode}"),
+          item_url = Some(buildUrl(content.webUrl, variant)),
           subtitle = content.fields.flatMap(_.standfirst.map(Jsoup.parse(_).text)),
           image_url = Some(getImageUrl(content)),
           buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
@@ -36,6 +36,10 @@ object FacebookMessageBuilder {
       ))
     }
   }
+
+  //Include the variant in the campaign code if present
+  private def buildUrl(webUrl: String, variant: Option[String]): String =
+    s"$webUrl?CMP=${BotConfig.campaignCode}${variant.map(v => s"_$v").getOrElse("")}"
 
   // Look for widest image up to MaxImageWidth
   private def getImageUrl(content: Content): String = {

--- a/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
@@ -40,5 +40,12 @@ object ResponseText {
 
   def editionChanged(edition: String) = s"Your edition has been updated to $edition"
 
+  def morningBriefing = random(List(
+    "Good morning! Here are the top stories today",
+    "Good morning! Your briefing is ready for you",
+    "Good morning! Your briefing has arrived",
+    "Good morning! Check out this morning's headline stories"
+  ))
+
   private def random(list: List[String]) = list((Random.nextDouble * list.length).floor.toInt)
 }


### PR DESCRIPTION
This matches the morning briefing currently sent by the old node app.
A new actor object polls an SQS queue for users who should receive their morning briefings now, which is populated by the [lambda](https://github.com/guardian/facebook-news-bot-scheduler).
A carousel of editors-picks is sent. It also checks if the user's timezone has changed.

I've added the `variant` field to the User model (which is stored in dynamodb). This will be used for A/B testing later.