### PR TITLE
Verify signature in header

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -37,6 +37,7 @@ object BotConfig {
   object facebook {
     val url = getMandatoryString("facebook.url")
     val accessToken = getMandatoryString("facebook.accessToken")
+    val secret = getMandatoryString("facebook.secret")
   }
 
   object capi {

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -3,7 +3,9 @@ package com.gu.facebook_news_bot
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.server.Directives._
 import akka.actor.ActorSystem
+import akka.http.scaladsl.model.StatusCodes
 import akka.stream.{ActorMaterializer, Materializer}
+import akka.http.scaladsl.unmarshalling.PredefinedFromEntityUnmarshallers
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
@@ -15,13 +17,13 @@ import de.heikoseeberger.akkahttpcirce.CirceSupport
 import io.circe.generic.auto._
 import com.gu.facebook_news_bot.state.StateHandler
 import com.gu.facebook_news_bot.stores.UserStore
-import com.gu.facebook_news_bot.utils.JsonHelpers
+import com.gu.facebook_news_bot.utils.{JsonHelpers, Verification}
 import com.typesafe.scalalogging.StrictLogging
 
 import scala.concurrent.ExecutionContextExecutor
 import scala.util.{Failure, Success}
 
-trait BotService extends CirceSupport with StrictLogging {
+trait BotService extends CirceSupport with PredefinedFromEntityUnmarshallers with StrictLogging {
   implicit val system: ActorSystem
   implicit def executor: ExecutionContextExecutor
   implicit val materializer: Materializer
@@ -40,22 +42,33 @@ trait BotService extends CirceSupport with StrictLogging {
     }
   } ~ path("webhook") {
     post {
-      entity(as[MessageFromFacebook]) { fromFb =>
-        logger.debug(s"Received message from Facebook: ${JsonHelpers.encodeJson(fromFb)}")
-        complete {
-          /**
-            * A message from FB may contains many 'entries', each with many 'messagings', from any number of users.
-            * The order in which they are processed is not important.
-            * We respond immediately with a 200.
-            */
-          val messagings: Seq[MessageFromFacebook.Messaging] = for {
-            entry <- fromFb.entry
-            messaging <- entry.messaging
-          } yield messaging
+      //Verify the signature header before processing the request
+      headerValueByName("X-Hub-Signature") { signature =>
+        entity(as[Array[Byte]]) { bytes =>
+          if (Verification.verifySignature(signature, bytes)) {
 
-          messagings foreach { messaging =>
-            //For now, ignore message receipts
-            if (messaging.message.isDefined || messaging.postback.isDefined) processMessaging(messaging)
+            entity(as[MessageFromFacebook]) { fromFb =>
+              logger.debug(s"Received message from Facebook: ${JsonHelpers.encodeJson(fromFb)}")
+              complete {
+                /**
+                  * A message from FB may contains many 'entries', each with many 'messagings', from any number of users.
+                  * The order in which they are processed is not important.
+                  * We respond immediately with a 200.
+                  */
+                val messagings: Seq[MessageFromFacebook.Messaging] = for {
+                  entry <- fromFb.entry
+                  messaging <- entry.messaging
+                } yield messaging
+
+                messagings foreach { messaging =>
+                  //For now, ignore message receipts
+                  if (messaging.message.isDefined || messaging.postback.isDefined) processMessaging(messaging)
+                }
+              }
+            }
+          } else {
+            logger.warn(s"Invalid X-Hub-Signature header, rejecting POST request.")
+            complete(StatusCodes.Forbidden)
           }
         }
       }

--- a/src/main/scala/com/gu/facebook_news_bot/utils/Verification.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/Verification.scala
@@ -1,0 +1,31 @@
+package com.gu.facebook_news_bot.utils
+
+import java.nio.charset.StandardCharsets
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+import com.gu.facebook_news_bot.BotConfig
+import com.typesafe.scalalogging.StrictLogging
+import org.apache.commons.codec.binary.Hex
+
+/**
+  * From https://developers.facebook.com/docs/messenger-platform/webhook-reference#security:
+  *
+  * "The HTTP request will contain an X-Hub-Signature header which contains the SHA1 signature of the request payload,
+  * using the app secret as the key, and prefixed with 'sha1='."
+  */
+object Verification extends StrictLogging {
+  val CryptoAlgorithm = "HmacSHA1"
+
+  def verifySignature(signature: String, body: Array[Byte]): Boolean = {
+    signature.split("=").lastOption.exists { expectedHash =>
+      val secretKeySpec = new SecretKeySpec(BotConfig.facebook.secret.getBytes(StandardCharsets.UTF_8), CryptoAlgorithm)
+      val mac = Mac.getInstance(CryptoAlgorithm)
+      mac.init(secretKeySpec)
+      val result = mac.doFinal(body)
+
+      val computedHash = Hex.encodeHex(result).mkString
+      computedHash == expectedHash
+    }
+  }
+}


### PR DESCRIPTION
See https://developers.facebook.com/docs/messenger-platform/webhook-reference#security for details.

FB includes an X-Hub-Signature header in its requests, which we can check against the hash of the body using the secret for the FB app.