### PR TITLE
Menu quick replies, changes to the copy

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
@@ -62,7 +62,7 @@ object MessageToFacebook {
     )
   }
 
-  case class QuickReply(content_type: String,
+  case class QuickReply(content_type: String = "text",
                         title: Option[String] = None,
                         payload: Option[String] = None,
                         image_url: Option[String] = None)

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -36,14 +36,16 @@ object FacebookMessageBuilder {
     }
   }
 
-  private def topicQuickReplies(edition: String): List[MessageToFacebook.QuickReply] = {
-    val topicNames = edition match {
-      case "us" => List("Politics", "Sport", "Business")
-      case "au" => List("Politics", "Sport", "Business", "Culture")
-      case "international" => List("Sport", "Business", "Technology")
-      case _ => List("Politics", "Football", "Business", "Sport")
-    }
+  def topicQuickReplies(edition: String): List[MessageToFacebook.QuickReply] = {
+    val topicNames = suggestedTopics(edition)
     topicNames.map(t => MessageToFacebook.QuickReply(content_type = "text", title = Some(t), payload = Some(t.toLowerCase())))
+  }
+
+  def suggestedTopics(edition: String): List[String] = edition match {
+    case "us" => List("Politics", "Sport", "Business")
+    case "au" => List("Politics", "Sport", "Business", "Culture")
+    case "international" => List("Sport", "Business", "Technology")
+    case _ => List("Politics", "Football", "Lifestyle", "Sport", "Tech")
   }
 
   //Include the variant in the campaign code if present

--- a/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
@@ -10,21 +10,17 @@ object ResponseText {
     "Hey"
   ))
 
-  def welcome = "Hi, I'm a prototype chatbot created by the Guardian to keep you up-to-date with the latest news.\n\nWould you like me to deliver a daily morning briefing to you?"
+  def welcome = "Hi, I'm the Guardian chatbot. I'll keep you up-to-date with the latest news.\n\nWould you like me to deliver a daily morning briefing to you?"
 
-  def unknown = random(List(
-    "I'm sorry, I didn't understand that. I'm only good at simple instructions and sending out headlines at the moment",
-    "I'm sorry, I didn't understand that. My creators are working hard to make me smarter and more useful for you",
-    "I'm sorry, I didn't understand that. Typing 'menu' at anytime will bring up the options menu"
-  ))
+  def unknown = "I'm sorry, I didn't understand that. Typing 'menu' at anytime will bring up the options menu."
 
   def noResults = "Sorry, I don't have any stories on that at the moment"
 
   def menu = "How can I help?"
 
-  def help = "I'm a prototype chatbot created by the Guardian to keep you up-to-date with the latest news.\\n\\nI can give you the headlines, the most popular stories or deliver a morning briefing to you.\\n\\nHow can I help you today?"
+  def help = "I'm the Guardian chatbot. I can keep you up-to-date with the latest news.\n\nI can give you the headlines, the most popular stories or deliver a morning briefing to you.\n\nHow can I help you today?"
 
-  def briefingTimeQuestion = "When would you like your morning briefing delivered?"
+  def briefingTimeQuestion = "When would you like your morning briefing delivered? You can choose from 6, 7 or 8am."
 
   def subscribeQuestion = "Would you like to subscribe to the daily morning briefing?"
 
@@ -46,6 +42,8 @@ object ResponseText {
     "Good morning! Your briefing has arrived",
     "Good morning! Check out this morning's headline stories"
   ))
+
+  def suggest = "You can ask for headlines or the most popular stories for various topics. Here are some examples:"
 
   private def random(list: List[String]) = list((Random.nextDouble * list.length).floor.toInt)
 }

--- a/src/test/resources/facebookResponses/headlines.json
+++ b/src/test/resources/facebookResponses/headlines.json
@@ -105,14 +105,20 @@
       },
       {
         "content_type" : "text",
-        "title" : "Business",
-        "payload" : "business",
+        "title" : "Lifestyle",
+        "payload" : "lifestyle",
         "image_url" : null
       },
       {
         "content_type" : "text",
         "title" : "Sport",
         "payload" : "sport",
+        "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Tech",
+        "payload" : "tech",
         "image_url" : null
       }
     ],

--- a/src/test/resources/facebookResponses/moreHeadlines.json
+++ b/src/test/resources/facebookResponses/moreHeadlines.json
@@ -105,14 +105,20 @@
       },
       {
         "content_type" : "text",
-        "title" : "Business",
-        "payload" : "business",
+        "title" : "Lifestyle",
+        "payload" : "lifestyle",
         "image_url" : null
       },
       {
         "content_type" : "text",
         "title" : "Sport",
         "payload" : "sport",
+        "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Tech",
+        "payload" : "tech",
         "image_url" : null
       }
     ],

--- a/src/test/resources/facebookResponses/morePoliticsHeadlines.json
+++ b/src/test/resources/facebookResponses/morePoliticsHeadlines.json
@@ -105,14 +105,20 @@
       },
       {
         "content_type" : "text",
-        "title" : "Business",
-        "payload" : "business",
+        "title" : "Lifestyle",
+        "payload" : "lifestyle",
         "image_url" : null
       },
       {
         "content_type" : "text",
         "title" : "Sport",
         "payload" : "sport",
+        "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Tech",
+        "payload" : "tech",
         "image_url" : null
       }
     ],

--- a/src/test/resources/facebookResponses/newUser.json
+++ b/src/test/resources/facebookResponses/newUser.json
@@ -3,7 +3,7 @@
     "id":"subscription_test"
   },
   "message":{
-    "text":"Hi, I'm a prototype chatbot created by the Guardian to keep you up-to-date with the latest news.\n\nWould you like me to deliver a daily morning briefing to you?",
+    "text":"Hi, I'm the Guardian chatbot. I'll keep you up-to-date with the latest news.\n\nWould you like me to deliver a daily morning briefing to you?",
     "quick_replies":[
       {
         "content_type":"text",

--- a/src/test/resources/facebookResponses/politicsHeadlines.json
+++ b/src/test/resources/facebookResponses/politicsHeadlines.json
@@ -105,14 +105,20 @@
       },
       {
         "content_type" : "text",
-        "title" : "Business",
-        "payload" : "business",
+        "title" : "Lifestyle",
+        "payload" : "lifestyle",
         "image_url" : null
       },
       {
         "content_type" : "text",
         "title" : "Sport",
         "payload" : "sport",
+        "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Tech",
+        "payload" : "tech",
         "image_url" : null
       }
     ],

--- a/src/test/resources/facebookResponses/yesSubscribe.json
+++ b/src/test/resources/facebookResponses/yesSubscribe.json
@@ -3,7 +3,7 @@
     "id":"subscription_test"
   },
   "message":{
-    "text":"When would you like your morning briefing delivered?",
+    "text":"When would you like your morning briefing delivered? You can choose from 6, 7 or 8am.",
     "quick_replies":[
       {
         "content_type":"text",


### PR DESCRIPTION
Quick replies are better than buttons because:
1. We can have more than 3
2. They vanish after the next message. Buttons persist, which means they can be clicked out of context later on

This change replaces the menu buttons with quick replies, and adds a new quick reply, "Suggest something". This is for telling the user that they can ask for topics. When we add more features in the future we can use this menu to tell users about them.

![picture 2](https://cloud.githubusercontent.com/assets/1513454/19801393/f11935da-9cf6-11e6-96ab-cc5702f90123.png)

![picture 3](https://cloud.githubusercontent.com/assets/1513454/19801994/6e09e722-9cf9-11e6-9f92-c82e0a414e1c.png)
