### PR TITLE
Improve quick replies after carousel

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
@@ -110,6 +110,7 @@ sealed trait Topic {
   val terms: List[String]
   lazy val pattern: Regex = ("""(^|\W)(""" + terms.mkString("|") + """)($|\W)""").r.unanchored
   def getPath(edition: String): String
+  def name: String = terms.headOption.getOrElse("")
 }
 
 case class SectionTopic(terms: List[String], section: String) extends Topic {

--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -75,7 +75,7 @@ case object MainState extends State {
       case NewContentEvent(maybeContentType, maybeTopic) =>
         //Either have a new contentType, or use an existing contentType
         maybeContentType.orElse(user.contentType.flatMap(ContentType.fromString)) map { contentType =>
-          log(ContentLogEvent(user.ID, contentType.name, maybeTopic.flatMap(_.terms.headOption).getOrElse(""), 0))
+          log(ContentLogEvent(user.ID, contentType.name, maybeTopic.map(_.name).getOrElse(""), 0))
 
           carousel(user, contentType, maybeTopic, 0, capi)
         }
@@ -150,8 +150,8 @@ case object MainState extends State {
 
   private def carousel(user: User, contentType: ContentType, topic: Option[Topic], offset: Int, capi: Capi, variant: Option[String] = None): Future[Result] = {
     val futureCarousel = contentType match {
-      case MostViewedType => capi.getMostViewed(user.front, topic) map (contentToCarousel(_, offset, user.front, variant))
-      case HeadlinesType => capi.getHeadlines(user.front, topic) map (contentToCarousel(_, offset, user.front, variant))
+      case MostViewedType => capi.getMostViewed(user.front, topic) map (contentToCarousel(_, offset, user.front, topic.map(_.name), variant))
+      case HeadlinesType => capi.getHeadlines(user.front, topic) map (contentToCarousel(_, offset, user.front, topic.map(_.name), variant))
     }
 
     futureCarousel map {
@@ -159,7 +159,7 @@ case object MainState extends State {
         val updatedUser = user.copy(
           state = Some(Name),
           contentType = Some(contentType.name),
-          contentTopic = topic.map(_.terms.headOption.getOrElse("")),
+          contentTopic = topic.map(_.name),
           contentOffset = Some(offset)
         )
 

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -29,7 +29,7 @@ object FacebookMessageBuilder {
         attachment = Some(attachment),
         quick_replies = Some(List(MessageToFacebook.QuickReply(
           content_type = "text",
-          title = Some(currentTopic.map(topic => s"More $topic stories").getOrElse("More stories")),
+          title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
           payload = Some("more")
         )) ++ topicQuickReplies(edition, currentTopic))
       ))

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -10,7 +10,7 @@ object FacebookMessageBuilder {
   val MaxImageWidth = 1000
   val CarouselSize = 5  //Number of items in a carousel
 
-  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, variant: Option[String] = None): Option[MessageToFacebook.Message] = {
+  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, currentTopic: Option[String], variant: Option[String] = None): Option[MessageToFacebook.Message] = {
     val sliced = contentList.slice(offset, offset + CarouselSize)
     if (sliced.isEmpty) None
     else {
@@ -29,16 +29,17 @@ object FacebookMessageBuilder {
         attachment = Some(attachment),
         quick_replies = Some(List(MessageToFacebook.QuickReply(
           content_type = "text",
-          title = Some("More stories"),
+          title = Some(currentTopic.map(topic => s"More $topic stories").getOrElse("More stories")),
           payload = Some("more")
-        )) ++ topicQuickReplies(edition))
+        )) ++ topicQuickReplies(edition, currentTopic))
       ))
     }
   }
 
-  def topicQuickReplies(edition: String): List[MessageToFacebook.QuickReply] = {
+  def topicQuickReplies(edition: String, currentTopic: Option[String] = None): List[MessageToFacebook.QuickReply] = {
     val topicNames = suggestedTopics(edition)
-    topicNames.map(t => MessageToFacebook.QuickReply(content_type = "text", title = Some(t), payload = Some(t.toLowerCase())))
+    val filtered = currentTopic.map(current => topicNames.filterNot(_.toLowerCase == current)).getOrElse(topicNames)
+    filtered.map(t => MessageToFacebook.QuickReply(content_type = "text", title = Some(t), payload = Some(t.toLowerCase())))
   }
 
   def suggestedTopics(edition: String): List[String] = edition match {

--- a/src/test/resources/facebookResponses/morePoliticsHeadlines.json
+++ b/src/test/resources/facebookResponses/morePoliticsHeadlines.json
@@ -87,14 +87,8 @@
     "quick_replies" : [
       {
         "content_type" : "text",
-        "title" : "More stories",
+        "title" : "More politics",
         "payload" : "more",
-        "image_url" : null
-      },
-      {
-        "content_type" : "text",
-        "title" : "Politics",
-        "payload" : "politics",
         "image_url" : null
       },
       {

--- a/src/test/resources/facebookResponses/politicsHeadlines.json
+++ b/src/test/resources/facebookResponses/politicsHeadlines.json
@@ -87,14 +87,8 @@
     "quick_replies" : [
       {
         "content_type" : "text",
-        "title" : "More stories",
+        "title" : "More politics",
         "payload" : "more",
-        "image_url" : null
-      },
-      {
-        "content_type" : "text",
-        "title" : "Politics",
-        "payload" : "politics",
         "image_url" : null
       },
       {


### PR DESCRIPTION
Two improvements to the set of quick replies after the carousel:
1. If user is currently viewing stories for a topic, the `more` quick reply should specify the topic, e.g. "More politics stories" instead of just "More stories"
2. Filter out the quick reply for the topic that is currently being viewed.

![picture 3](https://cloud.githubusercontent.com/assets/1513454/19807264/40b5ba08-9d17-11e6-84e0-b6048be305ec.png)
