### PR TITLE
Make text field optional. Handle and log rejections.

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
@@ -89,7 +89,7 @@ object MessageFromFacebook {
 
   case class Message(mid: String,
                      seq: Int,
-                     text: String,
+                     text: Option[String],
                      attachments: Option[Seq[Attachment]],
                      quick_reply: Option[QuickReply])
 

--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -107,9 +107,9 @@ case object MainState extends State {
     result.getOrElse(State.unknown(user))
   }
 
-  //A Message must have a text field, but may also have a quick_reply
+  //If the message has a quick_reply use that, otherwise look for a text field
   private def processMessage(message: MessageFromFacebook.Message): Option[Event] =
-    message.quick_reply.flatMap(reply => processText(reply.payload)).orElse(processText(message.text))
+    message.quick_reply.flatMap(reply => processText(reply.payload)).orElse(processText(message.text.getOrElse("")))
 
   //On button click
   private def processButtonPostback(postback: MessageFromFacebook.Postback): Option[Event] = {

--- a/src/main/scala/com/gu/facebook_news_bot/state/State.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/State.scala
@@ -41,7 +41,7 @@ object State {
   def getUserInput(messaging: MessageFromFacebook.Messaging): Option[String] = {
     for {
       message <- messaging.message
-      value = message.quick_reply.map(_.payload).getOrElse(message.text)
+      value = message.quick_reply.map(_.payload).getOrElse(message.text.getOrElse(""))
     } yield value
   }
 }


### PR DESCRIPTION
The text field on the message from facebook should actually be optional. I discovered this when a user sent a message with a gif and no text, and the app didn't reject it properly. FB then refused to send any more messages until our app had handled it, so it basically stopped working in production.

Proof that it now rejects the gif properly:
![picture 4](https://cloud.githubusercontent.com/assets/1513454/19813315/1bdffad0-9d31-11e6-855b-c21006947cc1.png)
