### PR TITLE
Http fixes

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,5 @@
+akka.http {
+  host-connection-pool {
+    max-open-requests = 2048
+  }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -14,7 +14,7 @@
             <pattern>%date [%thread] %-5level %logger{36} - %msg%n%xException{3}</pattern>
         </encoder>
     </appender>
-    <logger name="appLogger" level="INFO" additivity="false">
+    <logger name="appLogger" level="DEBUG" additivity="false">
         <appender-ref ref="appLogger"/>
     </logger>
 
@@ -40,7 +40,7 @@
         </encoder>
     </appender>
 
-    <root level="INFO">
+    <root level="DEBUG">
         <appender-ref ref="console"/>
     </root>
 

--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -37,9 +37,13 @@ object BotConfig {
   }
 
   object facebook {
-    val url = getMandatoryString("facebook.url")
+    val host = getMandatoryString("facebook.host")
+    val version = getMandatoryString("facebook.version")
+    val port = getIntOrDefault("facebook.port", 443)
     val accessToken = getMandatoryString("facebook.accessToken")
     val secret = getMandatoryString("facebook.secret")
+    //Facebook must be https, but if running locally against a test service we need the option
+    val protocol = if (stage == Mode.Dev) "http" else "https"
   }
 
   object capi {
@@ -54,5 +58,8 @@ object BotConfig {
   }
   private def getMandatoryInt(name: String): Int = {
     Try(config.getInt(name)).getOrElse(sys.error(s"Error - missing mandatory config item, $name"))
+  }
+  private def getIntOrDefault(name: String, default: Int): Int = {
+    Try(config.getInt(name)).getOrElse(default)
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
@@ -90,10 +90,7 @@ object MessageFromFacebook {
   case class Message(mid: String,
                      seq: Int,
                      text: Option[String],
-                     attachments: Option[Seq[Attachment]],
                      quick_reply: Option[QuickReply])
-
-  case class Attachment(`type`: String, payload: Payload)
 
   case class Payload(url: Option[String])
 


### PR DESCRIPTION
Over the weekend the bot failed to send/receive requests frequently, for various reasons. This branch fixes it.

1. It hit akka-http's limit on maximum number of open requests. I've raised the limit a bit in the config file, but I've also changed the code to use a connection pool and a request queue, to ensure we stay within the limit.
2. Some requests arrive as streams. Normally they don't (in akka terms, they arrive with type `HttpEntity.Strict`), which is why I never saw this problem in CODE. But sometimes in PROD the requests arrive as streams and so need to be handled correctly. It's important to consume the entire entity, even if we're not interested in the body of a particular message - [docs](http://doc.akka.io/docs/akka/2.4/scala/http/common/http-model.html#HttpEntity).
3. Handle FB response streams - as above.
4. Removed `attachment` field from the facebook model. We don't allow attachments anyway, but the message didn't conform to the model and so was causing rejections.