### PR TITLE
Collections briefing

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -50,6 +50,14 @@ object BotConfig {
     val key = getMandatoryString("capi.key")
   }
 
+  val nextGenApiUrl = {
+    if (stage == Mode.Dev) ""
+    else getMandatoryString("nextGenApiUrl")
+  }
+
+  //Proportion of users in test variant B
+  val variantBProportion = getDoubleOrDefault("variantBProportion", 0.5)
+
   private def getMandatoryString(name: String): String = {
     Try(config.getString(name)).getOrElse(if (stage == Mode.Dev) "" else sys.error(s"Error - missing mandatory config item, $name"))
   }
@@ -61,5 +69,8 @@ object BotConfig {
   }
   private def getIntOrDefault(name: String, default: Int): Int = {
     Try(config.getInt(name)).getOrElse(default)
+  }
+  private def getDoubleOrDefault(name: String, default: Double): Double = {
+    Try(config.getDouble(name)).getOrElse(default)
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/CollectionsBriefing.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/CollectionsBriefing.scala
@@ -1,0 +1,152 @@
+package com.gu.facebook_news_bot.briefing
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpMethods, HttpRequest}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.models.{Id, MessageToFacebook, User}
+import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.utils.FacebookMessageBuilder
+import de.heikoseeberger.akkahttpcirce.CirceSupport
+import org.joda.time.{DateTime, DateTimeZone}
+import io.circe.generic.auto._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.util.Try
+
+/**
+  * Morning briefings created using the Collections tool
+  */
+
+case class CollectionsResponse(webTitle: String, collections: Seq[Collection]) {
+  def getCollection(displayName: String): Option[Collection] = {
+    collections.find(_.displayName == displayName)
+  }
+}
+case class Collection(displayName: String, content: Seq[CollectionsContent]) {
+  def getTimestamp: Option[DateTime] = {
+    //Find the most recent timestamp
+    content.headOption.map { head =>
+      val newestItem = content.fold(head)((newest, item) => if (item.frontPublicationDate > newest.frontPublicationDate) item else newest)
+      new DateTime(newestItem.frontPublicationDate, DateTimeZone.UTC)
+    }
+  }
+}
+case class CollectionsContent(headline: String, trailText: String, thumbnail: String, id: String, frontPublicationDate: Long)
+
+object CollectionsBriefing extends CirceSupport {
+  val VariantName = "collections"
+  val EditionToCollectionName = Map("uk" -> "morning-briefing")
+  val OldNewsThresholdHours = 4
+
+  implicit val system = ActorSystem("collections-actor-system")
+  implicit val materializer = ActorMaterializer()
+
+  /**
+    * Returns a morning briefing if the following conditions are met:
+    * 1. The user's ID puts them in the test group for variant B
+    * 2. The user's edition is supported
+    * 3. A collection can be retrieved from the cache or the NextGenApi
+    * 4. The collection is under OldNewsThresholdHours hours old, because old new is bad news.
+    */
+  def getBriefing(user: User): Future[Option[Result]] = {
+    val lastN: Float = Try(user.ID.takeRight(1).toFloat).getOrElse(9f)
+    if (lastN / 10f < BotConfig.variantBProportion && EditionToCollectionName.contains(user.front)) {
+
+      val futureCollection: Future[Option[CachedCollection]] =
+        CollectionsBriefingCache.get(user.front).map(cached => Future.successful(Some(cached)))
+        .getOrElse(getCollection(user))
+
+      futureCollection.map { maybeCollection =>
+        maybeCollection.flatMap { collection =>
+          //Check it's not old news
+          if (DateTime.now(DateTimeZone.UTC).minusHours(OldNewsThresholdHours).isBefore(collection.timestamp)) {
+            Some((user, collection.messages))
+          } else None
+        }
+      }
+
+    } else Future.successful(None)
+  }
+
+  private def getCollection(user: User): Future[Option[CachedCollection]] = {
+    requestCollection(EditionToCollectionName(user.front)).map { collectionsResponse =>
+
+      val maybeCollection: Option[CachedCollection] = for {
+        greetingCollection <- collectionsResponse.getCollection("greeting-message")
+        greetingContent <- greetingCollection.content.headOption
+        contentCollection <- collectionsResponse.getCollection("morning-briefing")
+        if contentCollection.content.nonEmpty
+        timestamp <- contentCollection.getTimestamp
+      } yield {
+        val greetingMessage = MessageToFacebook.textMessage(user.ID, greetingContent.headline)
+        val carouselMessage = MessageToFacebook(
+          recipient = Id(user.ID),
+          message = Some(buildCarousel(user.front, contentCollection))
+        )
+        CachedCollection(timestamp, List(greetingMessage, carouselMessage))
+      }
+
+      maybeCollection.foreach { collection =>
+        CollectionsBriefingCache.put(user.front, collection)
+      }
+      maybeCollection
+    }
+  }
+
+  private def requestCollection(name: String): Future[CollectionsResponse] = {
+    val responseFuture = Http().singleRequest(
+      request = HttpRequest(
+        method = HttpMethods.GET,
+        uri = s"${BotConfig.nextGenApiUrl}/$name/lite.json"
+      )
+    )
+    for {
+      response <- responseFuture
+      collectionsResponse <- Unmarshal(response.entity).to[CollectionsResponse]
+    } yield collectionsResponse
+  }
+
+  private def buildCarousel(edition: String, collection: Collection): MessageToFacebook.Message = {
+    val tiles = collection.content.take(10).map { content =>
+      MessageToFacebook.Element(
+        title = content.headline,
+        item_url = Some(buildUrl(content.id)),
+        subtitle = Some(content.trailText),
+        image_url = Some(content.thumbnail),
+        buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
+      )
+    }
+    val attachment = MessageToFacebook.Attachment.genericAttachment(tiles)
+
+    MessageToFacebook.Message(
+      attachment = Some(attachment),
+      quick_replies = Some(List(MessageToFacebook.QuickReply(
+        content_type = "text",
+        title = Some("Popular stories"),
+        payload = Some("popular")
+      )) ++ FacebookMessageBuilder.topicQuickReplies(edition))
+    )
+  }
+
+  private def buildUrl(id: String) = s"https://www.theguardian.com/$id?CMP=${BotConfig.campaignCode}&variant=$VariantName"
+}
+
+case class CachedCollection(timestamp: DateTime, messages: List[MessageToFacebook])
+
+object CollectionsBriefingCache {
+  private val CacheExpireMinutes = 2
+
+  private val cache = Caffeine.newBuilder()
+    .expireAfterWrite(CacheExpireMinutes, TimeUnit.MINUTES)
+    .build[String, CachedCollection]()
+
+  def get(edition: String): Option[CachedCollection] = Option(cache.getIfPresent(edition))
+  def put(edition: String, results: CachedCollection): Unit = cache.put(edition, results)
+}

--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -12,5 +12,4 @@ case class User(ID: String,
                 version: Option[Long] = None,
                 contentTopic: Option[String] = None,
                 contentOffset: Option[Int] = None,
-                contentType: Option[String] = None,
-                variant: Option[String] = None)
+                contentType: Option[String] = None)

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -49,9 +49,9 @@ object FacebookMessageBuilder {
     case _ => List("Politics", "Football", "Lifestyle", "Sport", "Tech")
   }
 
-  //Include the variant in the campaign code if present
+  //Include the variant as a parameter if present
   private def buildUrl(webUrl: String, variant: Option[String]): String =
-    s"$webUrl?CMP=${BotConfig.campaignCode}${variant.map(v => s"_$v").getOrElse("")}"
+    s"$webUrl?CMP=${BotConfig.campaignCode}${variant.map(v => s"&variant=$v").getOrElse("")}"
 
   // Look for widest image up to MaxImageWidth
   private def getImageUrl(content: Content): String = {


### PR DESCRIPTION
### Existing briefing - `editors-picks`
Currently we only have one kind of morning briefing, which is a carousel built from the editors-picks for the user's edition. This is followed by some quick_replies suggesting topics, plus a "More stories" quick_reply.

![picture 7](https://cloud.githubusercontent.com/assets/1513454/19895269/016bcfe8-a048-11e6-91b0-4b6d4b419152.png)

### New briefing - `collections`
This change introduces an alternative morning briefing. This is also a carousel, but the greeting message and the content in the carousel are defined by Editorial, using the Collections tool. This will be followed by the same quick_replies as the old briefing, except the "More stories" quick_reply will be replaced with "Popular stories".

![picture 6](https://cloud.githubusercontent.com/assets/1513454/19895215/cfbb6c6a-a047-11e6-9bb6-2860fdca3756.png)

We use the front called `morning-briefing`. In here are two collections:
1. `morning-briefing` - the set of stories to be used.
2. `greeting-message` - has a single article whose headline is the greeting message to be used. This is a bit of a hack, but there's no other way to define a string in the front data.

Currently this briefing is only available to users with the UK edition selected.
The front must have been updated in the past 4 hours, otherwise it falls back on the `editors-picks` briefing. The results are cached locally for 2 mins.

### Testing
This PR adds *very* basic A/B testing, so that we can compare click-through from the two morning briefings. A new config value defines the proportion of users who should have the new briefing (default to 0.5). The urls in the briefings will contain a `variant` parameter with value of either `collections` or `editors-picks`.