### PR TITLE
Remove unused facebook user fields

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
@@ -101,4 +101,4 @@ object MessageFromFacebook {
 
 }
 
-case class FacebookUser(first_name: String, last_name: String, gender: String, locale: String, timezone: Double)
+case class FacebookUser(locale: String, timezone: Double)

--- a/src/test/scala/com/gu/facebook_news_bot/TestService.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/TestService.scala
@@ -15,11 +15,11 @@ import scala.concurrent.duration._
 
 class TestService(testName: String, createUser: Boolean = false) extends BotService with MockitoSugar {
   override val facebook = mock[Facebook]
-  when(facebook.getUser(anyString())).thenReturn(Future.successful(FacebookUser("mr", "test", "m", "en_GB", 1.25)))
+  when(facebook.getUser(anyString())).thenReturn(Future.successful(FacebookUser("en_GB", 1.25)))
   override val capi = DummyCapi
   override val stateHandler = StateHandler(facebook, capi)
   override val dynamoClient = LocalDynamoDB.client
-  override val usersTable = testName
+  override val usersTable = testName  
 
   override implicit val system = ActorSystem("facebook-news-bot-actor-system")
   override implicit val executor = system.dispatcher


### PR DESCRIPTION
These fields come from the facebook graph api, but we only use the locale and timezone.