### PR TITLE
"Support the Guardian" quick reply

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -18,6 +18,7 @@ object BotConfig {
   val port = getMandatoryInt("port")
 
   val defaultImageUrl = getMandatoryString("defaultImageUrl")
+  val supportersImageUrl = getMandatoryString("supportersImageUrl")
 
   val campaignCode = getStringOrDefault("campaignCode", "fb_newsbot")
 

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -172,7 +172,9 @@ object Bot extends App with BotService {
     case None => appLogger.warn(s"No kinesis stream name found for logging.")
   }
 
-  val poller = system.actorOf(MorningBriefingPoller.props(userStore, capi, facebook))
+  val poller = PartialFunction.condOpt(BotConfig.stage != Mode.Dev) {
+    case true => system.actorOf(MorningBriefingPoller.props(userStore, capi, facebook))
+  }
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)
 }

--- a/src/main/scala/com/gu/facebook_news_bot/services/Facebook.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Facebook.scala
@@ -52,10 +52,11 @@ class FacebookImpl extends Facebook with CirceSupport {
   }
 
   def getUser(id: String): Future[FacebookUser] = {
+    val port = if (BotConfig.stage == Mode.Dev) s":${BotConfig.facebook.port}" else ""
     val responseFuture = Http().singleRequest(
       HttpRequest(
         method = HttpMethods.GET,
-        uri = s"${BotConfig.facebook.protocol}://${BotConfig.facebook.host}/${BotConfig.facebook.version}/$id?access_token=${BotConfig.facebook.accessToken}"
+        uri = s"${BotConfig.facebook.protocol}://${BotConfig.facebook.host}$port/${BotConfig.facebook.version}/$id?access_token=${BotConfig.facebook.accessToken}"
       )
     )
 

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -25,15 +25,25 @@ object FacebookMessageBuilder {
       }
       val attachment = MessageToFacebook.Attachment.genericAttachment(tiles)
 
+      val moreQuickReply = MessageToFacebook.QuickReply(
+        content_type = "text",
+        title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
+        payload = Some("more")
+      )
+
       Some(MessageToFacebook.Message(
         attachment = Some(attachment),
-        quick_replies = Some(List(MessageToFacebook.QuickReply(
-          content_type = "text",
-          title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
-          payload = Some("more")
-        )) ++ topicQuickReplies(edition, currentTopic))
+        quick_replies = Some(moreQuickReply :: topicQuickReplies(edition, currentTopic) ::: supportUsQuickReply :: Nil)
       ))
     }
+  }
+
+  def supportUsQuickReply = {
+    MessageToFacebook.QuickReply(
+      content_type = "text",
+      title = Some("Support the Guardian"),
+      payload = Some("support")
+    )
   }
 
   def topicQuickReplies(edition: String, currentTopic: Option[String] = None): List[MessageToFacebook.QuickReply] = {
@@ -78,5 +88,33 @@ object FacebookMessageBuilder {
         case width if width <= MaxImageWidth && width > widest => thisAsset
       } orElse widestAsset
     }
+  }
+
+  def supportUsCarousel(userEdition: String): MessageToFacebook.Message = {
+    val edition = if (userEdition == "international") "uk" else userEdition
+    val campaignCode = s"INTCMP=${BotConfig.campaignCode}"
+
+    val tiles = List(
+      MessageToFacebook.Element(
+        title = "Become a Guardian Supporter",
+        item_url = Some(s"https://membership.theguardian.com/$edition/supporter?$campaignCode"),
+        image_url = Some(BotConfig.supportersImageUrl),
+        buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
+      ),
+      MessageToFacebook.Element(
+        title = "Contribute to the Guardian",
+        item_url = Some(s"https://contribute.theguardian.com/$edition?$campaignCode"),
+        image_url = Some(BotConfig.supportersImageUrl),
+        buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
+      ),
+      MessageToFacebook.Element(
+        title = "How technology disrupted the truth",
+        item_url = Some(s"https://www.theguardian.com/media/2016/jul/12/how-technology-disrupted-the-truth?$campaignCode"),
+        image_url = Some("https://media.guim.co.uk/328e9120d07331a2458e2acdb2ba033fe1b672fe/0_0_5000_3000/1000.jpg"),
+        buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
+      )
+    )
+
+    MessageToFacebook.Message(attachment = Some(MessageToFacebook.Attachment.genericAttachment(tiles)))
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
@@ -57,5 +57,7 @@ object ResponseText {
 
   def suggest = "You can ask for headlines or the most popular stories for various topics. Here are some examples:"
 
+  def support = "Producing well-reported journalism is difficult and expensive. Supporting us isn't. Please support the Guardian."
+
   private def random(list: List[String]) = list((Random.nextDouble * list.length).floor.toInt)
 }

--- a/src/test/resources/facebookResponses/briefingTime.json
+++ b/src/test/resources/facebookResponses/briefingTime.json
@@ -29,6 +29,12 @@
         "content_type":"text",
         "title":"Give us feedback",
         "payload":"feedback"
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
       }
     ]
   }

--- a/src/test/resources/facebookResponses/headlines.json
+++ b/src/test/resources/facebookResponses/headlines.json
@@ -120,6 +120,12 @@
         "title" : "Tech",
         "payload" : "tech",
         "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
       }
     ],
     "metadata" : null

--- a/src/test/resources/facebookResponses/moreHeadlines.json
+++ b/src/test/resources/facebookResponses/moreHeadlines.json
@@ -120,6 +120,12 @@
         "title" : "Tech",
         "payload" : "tech",
         "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
       }
     ],
     "metadata" : null

--- a/src/test/resources/facebookResponses/morePoliticsHeadlines.json
+++ b/src/test/resources/facebookResponses/morePoliticsHeadlines.json
@@ -114,6 +114,12 @@
         "title" : "Tech",
         "payload" : "tech",
         "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
       }
     ],
     "metadata" : null

--- a/src/test/resources/facebookResponses/politicsHeadlines.json
+++ b/src/test/resources/facebookResponses/politicsHeadlines.json
@@ -114,6 +114,12 @@
         "title" : "Tech",
         "payload" : "tech",
         "image_url" : null
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
       }
     ],
     "metadata" : null


### PR DESCRIPTION
The final quick reply after the carousel and in the menu now says "Support the Guardian":
<img width="632" alt="picture 6" src="https://cloud.githubusercontent.com/assets/1513454/20063855/936d784e-a500-11e6-9510-738cc4997e9b.png">

Clicking this brings up a carousel with 3 links: membership, contributions, and Kath's long read:
<img width="613" alt="picture 7" src="https://cloud.githubusercontent.com/assets/1513454/20063861/9925c23c-a500-11e6-83c5-fc3c99a64062.png">

I also made some small changes to help with running it locally.