### PR TITLE
Log referrals

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/FacebookModels.scala
@@ -97,7 +97,9 @@ object MessageFromFacebook {
   //quick_reply and postback payloads contain the string that we supplied - this is different from the attachment payloads.
   case class QuickReply(payload: String)
 
-  case class Postback(payload: String)
+  case class Postback(payload: String, referral: Option[Referral])
+
+  case class Referral(ref: String, source: String, `type`: String)
 
 }
 


### PR DESCRIPTION
Facebook have [*just*](https://developers.facebook.com/docs/messenger-platform/referral-params) added support for a `ref` parameter in m.me links to messenger. This means we can log referrals from e.g. Instant Articles.

When a new user arrives, the app now checks the `postback` object for a `referral` object.