### PR TITLE
Append edition to variant name

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/briefing/CollectionsBriefing.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/CollectionsBriefing.scala
@@ -114,7 +114,7 @@ object CollectionsBriefing extends CirceSupport {
     val tiles = collection.content.take(10).map { content =>
       MessageToFacebook.Element(
         title = content.headline,
-        item_url = Some(buildUrl(content.id)),
+        item_url = Some(buildUrl(content.id, edition)),
         subtitle = Some(content.trailText),
         image_url = Some(content.thumbnail),
         buttons = Some(List(MessageToFacebook.Button(`type` = "element_share")))
@@ -132,7 +132,7 @@ object CollectionsBriefing extends CirceSupport {
     )
   }
 
-  private def buildUrl(id: String) = s"https://www.theguardian.com/$id?CMP=${BotConfig.campaignCode}&variant=$VariantName"
+  private def buildUrl(id: String, edition: String) = s"https://www.theguardian.com/$id?CMP=${BotConfig.campaignCode}&variant=$VariantName-$edition"
 }
 
 case class CachedCollection(timestamp: DateTime, messages: List[MessageToFacebook.Message])

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
@@ -107,7 +107,7 @@ class MorningBriefingPoller(userStore: UserStore, capi: Capi, facebook: Facebook
     CollectionsBriefing.getBriefing(user).flatMap { maybeBriefing: Option[Result] =>
       maybeBriefing.map(Future.successful).getOrElse {
         //Fall back on editors-picks briefing
-        MainState.getHeadlines(user, capi, variant = Some("editors-picks")) map { case (updatedUser, messages) =>
+        MainState.getHeadlines(user, capi, Some(s"editors-picks-${user.front}")) map { case (updatedUser, messages) =>
           (updatedUser, morningMessage(updatedUser) :: messages)
         }
       }


### PR DESCRIPTION
Only UK users get the `collections` briefing, so in order to compare click-through with the `editors-picks` briefing we need to filter out non-UK click-throughs.
We track which briefing they came from using the `variant` url param. This should not be included for non-uk users.