### PR TITLE
Record uncontactable users

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -12,4 +12,5 @@ case class User(ID: String,
                 version: Option[Long] = None,
                 contentTopic: Option[String] = None,
                 contentOffset: Option[Int] = None,
-                contentType: Option[String] = None)
+                contentType: Option[String] = None,
+                daysUncontactable: Option[Int] = None)

--- a/src/test/scala/com/gu/facebook_news_bot/TestService.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/TestService.scala
@@ -5,6 +5,7 @@ import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest, MediaType
 import akka.stream.ActorMaterializer
 import com.gu.facebook_news_bot.models.{FacebookUser, User}
 import com.gu.facebook_news_bot.services.Facebook
+import com.gu.facebook_news_bot.services.Facebook.GetUserSuccessResponse
 import com.gu.facebook_news_bot.state.StateHandler
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -15,7 +16,7 @@ import scala.concurrent.duration._
 
 class TestService(testName: String, createUser: Boolean = false) extends BotService with MockitoSugar {
   override val facebook = mock[Facebook]
-  when(facebook.getUser(anyString())).thenReturn(Future.successful(FacebookUser("en_GB", 1.25)))
+  when(facebook.getUser(anyString())).thenReturn(Future.successful(GetUserSuccessResponse(FacebookUser("en_GB", 1.25))))
   override val capi = DummyCapi
   override val stateHandler = StateHandler(facebook, capi)
   override val dynamoClient = LocalDynamoDB.client


### PR DESCRIPTION
In general this change models facebook responses and handles errors better.

Errors can occur for a variety of reasons, but ordinarily should only happen when a user has deleted the conversation. Currently the app quietly fails to send morning briefings to any users who have done this, day after day. Really we'd like to track these users, to get a better idea of how many subscribers we really have.

Before sending a morning briefing, the app gets the user's data from FB, to check their timezone hasn't changed. If the user is not contactable, FB returns a 200 with an empty body. When this occurs, increment the `daysUncontactable` field in dynamodb.