### PR TITLE
Change name of timestamp field in logging

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/utils/Loggers.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/Loggers.scala
@@ -17,7 +17,7 @@ object Loggers {
 
   def logEvent(json: Json): Unit = {
     //We only write json to event.log, so insert a timestamp here
-    val withTime = json.mapObject(_.add("timestamp", Json.fromString(DateTime.now(DateTimeZone.UTC).toString)))
+    val withTime = json.mapObject(_.add("timestamp_bot", Json.fromString(DateTime.now(DateTimeZone.UTC).toString)))
     eventLogger.info(withTime.noSpaces)
   }
 }


### PR DESCRIPTION
This causes a type conflict with the default timestamp field in kibana. It is useful to have the timestamp here though.