### PR TITLE
Find cloudformation by name rather than tags

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -17,3 +17,4 @@ deployments:
         AmigoStage: PROD
       cloudFormationStackName: facebook-news-bot
       prependStackToCloudFormationStackName: false
+      cloudFormationStackByTags: false


### PR DESCRIPTION
Riff-raff is about to support finding cloudformation stacks by tags.  The default behaviour for yaml configs will now be `cloudFormationStackByTags: true`.  Changing here to keep existing behaviour.