### PR TITLE
Send events to fb

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -45,6 +45,8 @@ object BotConfig {
     val secret = getMandatoryString("facebook.secret")
     //Facebook must be https, but if running locally against a test service we need the option
     val protocol = if (stage == Mode.Dev) "http" else "https"
+    val appId = getMandatoryString("facebook.appId")
+    val pageId = getMandatoryString("facebook.pageId")
   }
 
   object capi {

--- a/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
@@ -5,7 +5,7 @@ import com.gu.facebook_news_bot.services.Facebook.GetUserSuccessResponse
 import com.gu.facebook_news_bot.services.{Capi, Facebook}
 import com.gu.facebook_news_bot.state.StateHandler.Result
 import com.gu.facebook_news_bot.utils.ResponseText
-import com.gu.facebook_news_bot.utils.Loggers.appLogger
+import com.gu.facebook_news_bot.utils.Loggers.{LogEvent, appLogger}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 import io.circe.generic.auto._
@@ -23,7 +23,7 @@ case object BriefingTimeQuestionState extends State {
 
   val ValidTimes = Seq("6", "7", "8")
 
-  private case class BriefingTimeEvent(id: String, event: String = "subscribe", time: String) extends LogEvent
+  private case class BriefingTimeEvent(id: String, event: String = "subscribe", _eventName: String = "subscribe", time: String) extends LogEvent
 
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook): Future[Result] = {
     messaging.postback.map(MainState.onMenuButtonClick(user, _, capi, facebook)) getOrElse {

--- a/src/main/scala/com/gu/facebook_news_bot/state/EditionQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/EditionQuestionState.scala
@@ -3,6 +3,7 @@ package com.gu.facebook_news_bot.state
 import com.gu.facebook_news_bot.models.{Id, MessageFromFacebook, MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, Facebook}
 import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
 import com.gu.facebook_news_bot.utils.ResponseText
 import io.circe.generic.auto._
 
@@ -18,7 +19,7 @@ case object EditionQuestionState extends State {
 
   val Editions = Seq("au", "uk", "us", "international")
 
-  private case class EditionEvent(id: String, event: String = "change_edition", edition: String) extends LogEvent
+  private case class EditionEvent(id: String, event: String = "change_edition", _eventName: String = "change_edition", edition: String) extends LogEvent
 
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook): Future[Result] = {
     messaging.postback.map(MainState.onMenuButtonClick(user, _, capi, facebook)) getOrElse {

--- a/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
@@ -3,6 +3,7 @@ package com.gu.facebook_news_bot.state
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, Facebook}
 import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
 import com.gu.facebook_news_bot.utils.ResponseText
 import io.circe.generic.auto._
 
@@ -11,7 +12,7 @@ import scala.concurrent.Future
 object FeedbackState extends State {
   val Name = "FEEDBACK"
 
-  private case class LogFeedback(id: String, event: String = "feedback", feedback: String) extends LogEvent
+  private case class LogFeedback(id: String, event: String = "feedback", _eventName: String = "feedback", feedback: String) extends LogEvent
 
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook): Future[Result] = {
     val result = for {

--- a/src/main/scala/com/gu/facebook_news_bot/state/State.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/State.scala
@@ -1,7 +1,7 @@
 package com.gu.facebook_news_bot.state
 
-import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
-import com.gu.facebook_news_bot.services.{Capi, Facebook}
+import com.gu.facebook_news_bot.models.{MessageFromFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook, FacebookEvents}
 import com.gu.facebook_news_bot.state.StateHandler.Result
 import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText}
 import com.gu.facebook_news_bot.utils.Loggers._
@@ -20,12 +20,10 @@ trait State {
     * Each State can optionally perform additional logging using an object with type LogEvent.
     * It will be logged as JSON
     */
-  protected trait LogEvent {
-    val id: String    //user's ID
-    val event: String  //the name of the event being logged
-  }
   protected def log[T <: LogEvent : ObjectEncoder](event: T): Unit = {
-    logEvent(JsonHelpers.encodeJson(event))
+    val json = JsonHelpers.encodeJson(event)
+    logEvent(json)
+    FacebookEvents.logEvent(event)
   }
 }
 

--- a/src/main/scala/com/gu/facebook_news_bot/state/SubscribeQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/SubscribeQuestionState.scala
@@ -3,6 +3,7 @@ package com.gu.facebook_news_bot.state
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, Facebook}
 import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
 import com.gu.facebook_news_bot.utils.ResponseText
 import io.circe.generic.auto._
 
@@ -17,9 +18,9 @@ case object SubscribeQuestionState extends State {
 
   private val YesPattern = "(yes|yeah|yep|sure)".r.unanchored
 
-  private case class SubscribeNoEvent(id: String, event: String = "subscribe_no") extends LogEvent
-  private case class SubscribeYesEvent(id: String, event: String = "subscribe_yes") extends LogEvent
-  private case class ReferralEvent(id: String, event: String = "referral", referrer: String) extends LogEvent
+  private case class SubscribeNoEvent(id: String, event: String = "subscribe_no", _eventName: String = "subscribe_no") extends LogEvent
+  private case class SubscribeYesEvent(id: String, event: String = "subscribe_yes", _eventName: String = "subscribe_yes") extends LogEvent
+  private case class ReferralEvent(id: String, event: String = "referral", _eventName: String = "referral", referrer: String) extends LogEvent
 
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook): Future[Result] = {
     messaging.postback.map(processPostback(user, _, capi, facebook)) getOrElse {

--- a/src/main/scala/com/gu/facebook_news_bot/utils/Loggers.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/Loggers.scala
@@ -5,6 +5,13 @@ import org.joda.time.{DateTime, DateTimeZone}
 import org.slf4j.LoggerFactory
 
 object Loggers {
+
+  trait LogEvent {
+    val id: String    //user's ID
+    val event: String  //the name of the event being logged (for compatiblity with kibana data)
+    val _eventName: String  //the name of the event for facebook analytics
+  }
+
   /**
     * eventLogger - populates the event.log file, which contains json-formatted event logging to be sent to logstash
     */


### PR DESCRIPTION
Currently the app sends event logs to kibana. Nobody likes Kibana.
FB now support custom event logging in their analytics tools. With this change, the app will send the same event logs to FB.

In the following image, I filtered the 'headlines' event by topic 'football'.
<img width="1008" alt="picture 1" src="https://cloud.githubusercontent.com/assets/1513454/20561344/13f7977a-b176-11e6-9324-0355f61dbc32.png">

This isn't as useful as I'd hoped, as there doesn't seem to be a way of comparing datasets, e.g. comparing the number of requests for each topic. Also, the smallest time interval is one day.

Note - the event name field for facebook analytics needs to be `_eventName`, whereas the field it's been using in kibana is `event`. The solution for now is just to include both fields in the logs, each with the same value.