### PR TITLE
Transfer notifications

### DIFF
--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -51,6 +51,9 @@ Parameters:
     MorningBriefingSnsTopicArn:
         Description: ARN of the morning briefings SNS topic
         Type: String
+    FootballTransfersSnsTopicArn:
+        Description: ARN of the football transfers SNS topic
+        Type: String
 
 Mappings:
     StageMap:
@@ -201,6 +204,7 @@ Resources:
                           - sqs:DeleteMessageBatch
                       Resource:
                           - !GetAtt MorningBriefingSQS.Arn
+                          - !GetAtt FootballTransfersSQS.Arn
             Roles:
                 - !Ref FacebookNewsBotRole
 
@@ -220,6 +224,23 @@ Resources:
                       Condition:
                           ArnEquals:
                               aws:SourceArn: !Ref MorningBriefingSnsTopicArn
+
+    FootballTransfersSQSPolicy:
+        Type: AWS::SQS::QueuePolicy
+        Properties:
+            Queues:
+                - !Ref FootballTransfersSQS
+            PolicyDocument:
+                Statement:
+                    - Sid: allow-sqs-sendmessage
+                      Effect: Allow
+                      Principal:
+                          AWS: "*"
+                      Action: SQS:SendMessage
+                      Resource: !GetAtt FootballTransfersSQS.Arn
+                      Condition:
+                          ArnEquals:
+                              aws:SourceArn: !Ref FootballTransfersSnsTopicArn
 
     InstanceProfile:
         Type: AWS::IAM::InstanceProfile
@@ -363,6 +384,11 @@ Resources:
         Type: AWS::SQS::Queue
         Properties:
             QueueName: !Sub facebook-news-bot-morning-briefing-${Stage}
+
+    FootballTransfersSQS:
+        Type: AWS::SQS::Queue
+        Properties:
+            QueueName: !Sub facebook-news-bot-football-transfers-${Stage}
 
     LaunchConfiguration:
         Type: AWS::AutoScaling::LaunchConfiguration

--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -55,7 +55,11 @@ object BotConfig {
   }
 
   object football {
+    val enabled = getBoolOrDefault("football.enabled", false)
+    val interactiveUrl = getMandatoryString("football.interactiveUrl")
     val api = getMandatoryString("football.sheetsApi")
+    val transfersSQSName = getMandatoryString("football.transfersSQSName")
+    val defaultImageUrl = getMandatoryString("football.defaultImageUrl")
   }
 
   val nextGenApiUrl = {
@@ -80,5 +84,8 @@ object BotConfig {
   }
   private def getDoubleOrDefault(name: String, default: Double): Double = {
     Try(config.getDouble(name)).getOrElse(default)
+  }
+  private def getBoolOrDefault(name: String, default: Boolean): Boolean = {
+    Try(config.getBoolean(name)).getOrElse(default)
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
@@ -15,6 +15,8 @@ import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText, SQSPoller}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
+import io.circe.generic.auto._
+
 import scala.concurrent.Future
 
 object MorningBriefingPoller {
@@ -30,7 +32,7 @@ object MorningBriefingPoller {
 
 class MorningBriefingPoller(val userStore: UserStore, val capi: Capi, val facebook: Facebook) extends SQSPoller {
   val SQSName = BotConfig.aws.morningBriefingSQSName
-
+  
   override def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] =
     JsonHelpers.decodeJson[User](messageBody.Message).map(user => processUser(user.ID)) getOrElse Future.successful(Nil)
 

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
@@ -1,34 +1,24 @@
 package com.gu.facebook_news_bot.briefing
 
-import java.util.concurrent.Executors
-
-import akka.actor.{Actor, Props}
+import akka.actor.Props
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
-import com.amazonaws.services.sqs.model.{DeleteMessageBatchRequest, DeleteMessageBatchRequestEntry, Message, ReceiveMessageRequest}
-import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.gu.facebook_news_bot.BotConfig
-import com.gu.facebook_news_bot.briefing.MorningBriefingPoller.{Poll, logBriefing}
+import com.gu.facebook_news_bot.briefing.MorningBriefingPoller.logBriefing
 import com.gu.facebook_news_bot.models.{MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.Facebook.{FacebookMessageResult, GetUserError, GetUserNoDataResponse, GetUserSuccessResponse}
-import com.gu.facebook_news_bot.services._
+import com.gu.facebook_news_bot.services.{Capi, Facebook, FacebookEvents, SQSMessageBody}
 import com.gu.facebook_news_bot.state.MainState
-import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.state.StateHandler._
 import com.gu.facebook_news_bot.stores.UserStore
-import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText}
 import com.gu.facebook_news_bot.utils.Loggers._
-import io.circe.generic.auto._
+import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText, SQSPoller}
 import org.joda.time.DateTime
 import org.joda.time.format.DateTimeFormat
 
-import scala.collection.JavaConverters._
-import scala.concurrent.{ExecutionContext, Future}
-import scala.concurrent.duration._
-import scala.util.{Failure, Success, Try}
+import scala.concurrent.Future
 
 object MorningBriefingPoller {
   def props(userStore: UserStore, capi: Capi, facebook: Facebook) = Props(new MorningBriefingPoller(userStore, capi, facebook))
-
-  case object Poll
 
   case class BriefingEventLog(id: String, event: String = "morning-briefing", _eventName: String = "morning-briefing", variant: String) extends LogEvent
   def logBriefing(id: String, variant: String): Unit = {
@@ -38,56 +28,11 @@ object MorningBriefingPoller {
   }
 }
 
-class MorningBriefingPoller(userStore: UserStore, capi: Capi, facebook: Facebook) extends Actor {
+class MorningBriefingPoller(val userStore: UserStore, val capi: Capi, val facebook: Facebook) extends SQSPoller {
+  val SQSName = BotConfig.aws.morningBriefingSQSName
 
-  private val MaxBatchSize = 10 //Max allowed by SQS
-  private val PollPeriod = 500.millis
-
-  implicit val exec = ExecutionContext.fromExecutorService(
-    Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("morning-briefing-poller-%d").build())
-  )
-
-  override def preStart(): Unit = self ! Poll
-
-  def receive = {
-    case Poll =>
-
-      val request = new ReceiveMessageRequest(BotConfig.aws.morningBriefingSQSName)
-        .withMaxNumberOfMessages(MaxBatchSize)
-        .withWaitTimeSeconds(10)
-
-      val messages: Seq[Message] = Try(SQS.client.receiveMessage(request)) match {
-        case Success(result) => result.getMessages.asScala
-        case Failure(e) =>
-          appLogger.error(s"Error polling SQS queue: ${e.getMessage}", e)
-          Nil
-      }
-
-      val decodedMessages = messages.flatMap(message => JsonHelpers.decodeJson[SQSMessageBody](message.getBody))
-      if (decodedMessages.nonEmpty) {
-        Future.sequence(decodedMessages.flatMap { decodedMessage =>
-          //TODO - change the lambda to only send the ID, as we don't want to rely on its User model being up to date
-          JsonHelpers.decodeJson[User](decodedMessage.Message).map(user => processUser(user.ID))
-        }).foreach { result =>
-          //Resume polling only once the requests have been sent
-          self ! Poll
-        }
-      } else context.system.scheduler.scheduleOnce(PollPeriod, self, Poll)
-
-      //Delete items from the queue
-      if (messages.nonEmpty) {
-        val deleteRequest = new DeleteMessageBatchRequest(
-          BotConfig.aws.morningBriefingSQSName,
-          messages.map(message => new DeleteMessageBatchRequestEntry(message.getMessageId, message.getReceiptHandle)).asJava
-        )
-        Try(SQS.client.deleteMessageBatch(deleteRequest)) recover {
-          case e => appLogger.warn(s"Failed to delete messages from queue: ${e.getMessage}", e)
-        }
-      }
-
-    case _ =>
-      appLogger.warn("Unknown message received by MorningBriefingPoller")
-  }
+  override def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] =
+    JsonHelpers.decodeJson[User](messageBody.Message).map(user => processUser(user.ID)) getOrElse Future.successful(Nil)
 
   private def processUser(userId: String): Future[List[FacebookMessageResult]] = {
     for {

--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfer.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfer.scala
@@ -1,0 +1,13 @@
+package com.gu.facebook_news_bot.football_transfers
+
+case class FootballTransfer(
+   player: String,
+   fromClub: String,
+   toClub: String,
+   fromLeague: String,
+   toLeague: String,
+   transferStatus: String,
+   transferType: String,
+   fee: Option[Int])
+
+case class UserFootballTransfer(userId: String, transfer: FootballTransfer)

--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
@@ -1,0 +1,103 @@
+package com.gu.facebook_news_bot.football_transfers
+
+import java.text.DecimalFormat
+
+import akka.actor.Props
+import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.models.{Id, MessageToFacebook}
+import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
+import com.gu.facebook_news_bot.services.{Facebook, FacebookEvents, SQSMessageBody}
+import com.gu.facebook_news_bot.state.FootballTransferStates
+import com.gu.facebook_news_bot.utils.Loggers._
+import com.gu.facebook_news_bot.utils.{JsonHelpers, SQSPoller}
+import io.circe.generic.auto._
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+class FootballTransfersPoller(val facebook: Facebook) extends SQSPoller {
+  val SQSName = BotConfig.football.transfersSQSName
+  override val PollPeriod = 2000.millis
+
+  protected def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] =
+    JsonHelpers.decodeJson[UserFootballTransfer](messageBody.Message).map(processUserTransfer) getOrElse Future.successful(Nil)
+
+  private def processUserTransfer(userTransfer: UserFootballTransfer): Future[List[FacebookMessageResult]] = {
+    val message = FootballTransfersPoller.buildTransferMessage(userTransfer)
+    FootballTransfersPoller.logNotification(userTransfer.userId, userTransfer.transfer.player)
+    facebook.send(List(message))
+  }
+}
+
+object FootballTransfersPoller {
+  def props(facebook: Facebook) = Props(new FootballTransfersPoller(facebook))
+
+  case class NotificationEventLog(id: String, event: String = "football-transfer-notification", _eventName: String = "football-transfer-notification", player: String) extends LogEvent
+  def logNotification(id: String, player: String): Unit = {
+    val eventLog = NotificationEventLog(id = id, player = player)
+    logEvent(JsonHelpers.encodeJson(eventLog))
+    FacebookEvents.logEvent(eventLog)
+  }
+
+  private val format = new DecimalFormat("0.##")
+  def prettifyFee(fee: Int): String = {
+    if (fee >= 1000000) s"£${format.format(fee / 1000000f)}m"
+    else if (fee >= 1000) s"£${format.format(fee / 1000f)}k"
+    else s"£$fee"
+  }
+
+  private def getImageUrl(name: String): String = {
+    FootballTransferStates.teams.get(name.toLowerCase).flatMap(_.imageUrl)
+      .getOrElse(BotConfig.football.defaultImageUrl)
+  }
+
+  private def buildTitle(transfer: FootballTransfer): String = {
+    transfer.transferStatus match {
+      case "agreed fees" => agreedFeesTitle(transfer)
+      case _ => doneDealTitle(transfer)
+    }
+  }
+
+  private def agreedFeesTitle(t: FootballTransfer): String = {
+    //We may not actually know the fee after an "agreed fees" announcement
+    t.fee match {
+      case Some(fee) => s"${t.fromClub} and ${t.toClub} have agreed a fee of ${FootballTransfersPoller.prettifyFee(t.fee.get)} for ${t.player} transfer"
+      case None => s"${t.fromClub} and ${t.toClub} have agreed a fee for ${t.player} transfer"
+    }
+  }
+
+  private def doneDealTitle(t: FootballTransfer): String = {
+    t.transferType match {
+      case "release" => s"${t.fromClub} has released ${t.player}"
+      case "loan ended" => s"${t.player} returns to ${t.toClub} from ${t.fromClub}"
+      case "loan" => s"${t.player} has joined ${t.toClub} on loan from ${t.fromClub}"
+      case "fee" if t.fee.isDefined =>
+        s"${t.player} has joined ${t.toClub} from ${t.fromClub} for ${FootballTransfersPoller.prettifyFee(t.fee.get)}"
+      case _ => s"${t.player} has joined ${t.toClub} from ${t.fromClub}"
+    }
+  }
+
+  def buildTransferMessage(userFootballTransfer: UserFootballTransfer): MessageToFacebook = {
+    val title = buildTitle(userFootballTransfer.transfer)
+    val button = MessageToFacebook.Button(
+      `type` = "web_url",
+      url = Some(s"${BotConfig.football.interactiveUrl}?CMP=${BotConfig.campaignCode}"),
+      title = Some("See more transfers")
+    )
+    val imageUrl = getImageUrl(userFootballTransfer.transfer.toClub)
+
+    val attachment = MessageToFacebook.Attachment.genericAttachment(Seq(
+      MessageToFacebook.Element(
+        title = title,
+        buttons = Some(Seq(button)),
+        image_url = Some(imageUrl)
+      )
+    ))
+
+    val message = MessageToFacebook.Message(attachment = Some(attachment))
+    MessageToFacebook(
+      recipient = Id(userFootballTransfer.userId),
+      message = Some(message)
+    )
+  }
+}

--- a/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
@@ -1,0 +1,77 @@
+package com.gu.facebook_news_bot.utils
+
+import java.util.concurrent.Executors
+
+import akka.actor.Actor
+import com.amazonaws.services.sqs.model.{DeleteMessageBatchRequest, DeleteMessageBatchRequestEntry, Message, ReceiveMessageRequest}
+import com.google.common.util.concurrent.ThreadFactoryBuilder
+import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
+import com.gu.facebook_news_bot.services._
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.Loggers._
+import com.gu.facebook_news_bot.utils.SQSPoller.Poll
+import io.circe.generic.auto._
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.duration._
+import scala.util.{Failure, Success, Try}
+
+object SQSPoller {
+  case object Poll
+}
+
+trait SQSPoller extends Actor {
+
+  val userStore: UserStore
+  val capi: Capi
+  val facebook: Facebook
+
+  val PollPeriod: FiniteDuration = 500.millis
+  val MaxBatchSize = 10 //Max allowed by SQS
+  val SQSName: String
+
+  implicit val exec = ExecutionContext.fromExecutorService(
+    Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("sqs-poller-%d").build())
+  )
+
+  override def preStart(): Unit = self ! Poll
+
+  def receive = {
+    case Poll =>
+
+      val request = new ReceiveMessageRequest(SQSName)
+        .withMaxNumberOfMessages(MaxBatchSize)
+        .withWaitTimeSeconds(10)
+
+      val messages: Seq[Message] = Try(SQS.client.receiveMessage(request)) match {
+        case Success(result) => result.getMessages.asScala
+        case Failure(e) =>
+          appLogger.error(s"Error polling SQS queue: ${e.getMessage}", e)
+          Nil
+      }
+
+      val decodedMessages = messages.flatMap(message => JsonHelpers.decodeJson[SQSMessageBody](message.getBody))
+      if (decodedMessages.nonEmpty) {
+        Future.sequence(decodedMessages.map(process)).foreach { result =>
+          //Resume polling only once the requests have been sent
+          self ! Poll
+        }
+      } else context.system.scheduler.scheduleOnce(PollPeriod, self, Poll)
+
+      //Delete items from the queue
+      if (messages.nonEmpty) {
+        val deleteRequest = new DeleteMessageBatchRequest(
+          SQSName,
+          messages.map(message => new DeleteMessageBatchRequestEntry(message.getMessageId, message.getReceiptHandle)).asJava
+        )
+        Try(SQS.client.deleteMessageBatch(deleteRequest)) recover {
+          case e => appLogger.warn(s"Failed to delete messages from queue: ${e.getMessage}", e)
+        }
+      }
+
+    case _ => appLogger.warn("Unknown message received by SQS Poller")
+  }
+
+  protected def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]]
+}

--- a/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
@@ -7,7 +7,6 @@ import com.amazonaws.services.sqs.model.{DeleteMessageBatchRequest, DeleteMessag
 import com.google.common.util.concurrent.ThreadFactoryBuilder
 import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
 import com.gu.facebook_news_bot.services._
-import com.gu.facebook_news_bot.stores.UserStore
 import com.gu.facebook_news_bot.utils.Loggers._
 import com.gu.facebook_news_bot.utils.SQSPoller.Poll
 import io.circe.generic.auto._
@@ -22,9 +21,6 @@ object SQSPoller {
 }
 
 trait SQSPoller extends Actor {
-
-  val userStore: UserStore
-  val capi: Capi
   val facebook: Facebook
 
   val PollPeriod: FiniteDuration = 500.millis

--- a/src/test/scala/com/gu/facebook_news_bot/FootballTransferTest.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/FootballTransferTest.scala
@@ -1,0 +1,64 @@
+package com.gu.facebook_news_bot
+
+import com.gu.facebook_news_bot.football_transfers.{FootballTransfer, FootballTransfersPoller, UserFootballTransfer}
+import com.gu.facebook_news_bot.models.{Id, MessageToFacebook}
+import org.scalatest.{FlatSpec, Matchers}
+
+class FootballTransferTest extends FlatSpec with Matchers {
+  it should "prettify 2 million" in {
+    FootballTransfersPoller.prettifyFee(2000000) should be("£2m")
+  }
+
+  it should "prettify 2.2 million" in {
+    FootballTransfersPoller.prettifyFee(2200000) should be("£2.2m")
+  }
+
+  it should "prettify 222.5 thousand" in {
+    FootballTransfersPoller.prettifyFee(222500) should be("£222.5k")
+  }
+
+  it should "prettify 200 quid?!" in {
+    FootballTransfersPoller.prettifyFee(200) should be("£200")
+  }
+
+  it should "build a transfer message" in {
+    val transfer = UserFootballTransfer(
+      userId = "3",
+      transfer = FootballTransfer(
+        player = "Joe Davies",
+        fromClub = "Leicester City",
+        toClub = "Manchester United",
+        fromLeague = "Premier League",
+        toLeague = "Premier League",
+        transferStatus = "done deal",
+        transferType = "fee",
+        fee = Some(2210000)
+      )
+    )
+
+    val expectedMessage = MessageToFacebook(
+      recipient = Id("3"),
+      message = Some(MessageToFacebook.Message(
+        attachment = Some(MessageToFacebook.Attachment(
+          `type` = "template",
+          payload = MessageToFacebook.Payload(
+            template_type = "generic",
+            elements = Some(Seq(
+              MessageToFacebook.Element(
+                title = "Joe Davies has joined Manchester United from Leicester City for £2.21m",
+                image_url = Some("fake-url/file.png"),
+                buttons = Some(List(MessageToFacebook.Button(
+                  `type` = "web_url",
+                  title = Some("See more transfers"),
+                  url = Some("?CMP=fb_newsbot")
+                )))
+              )
+            ))
+          )
+        ))
+      ))
+    )
+
+    FootballTransfersPoller.buildTransferMessage(transfer) should be(expectedMessage)
+  }
+}


### PR DESCRIPTION
The first commit refactors the `MorningBriefingPoller` to create a general `SQSPoller` trait. This will be used for more things in the future.

The `FootballTransfersPoller` polls a new SQS queue. This queue subscribes to the SNS topic of https://github.com/guardian/facebook-news-bot-football-transfers

The team crest image URLs are taken from the same api as the team aliases.

![picture 9](https://cloud.githubusercontent.com/assets/1513454/21344613/96b59ff8-c694-11e6-8ca3-2c31fb5235f1.png)