### PR TITLE
Store transfer rumour notification times

### DIFF
--- a/cloudformation/dynamodb-users.yml
+++ b/cloudformation/dynamodb-users.yml
@@ -17,6 +17,8 @@ Resources:
           AttributeType: S
         - AttributeName: notificationTimeUTC
           AttributeType: S
+        - AttributeName: footballRumoursTimeUTC
+          AttributeType: S
       KeySchema:
         - AttributeName: ID
           KeyType: HASH
@@ -31,6 +33,17 @@ Resources:
             ProjectionType: ALL
           ProvisionedThroughput:
             ReadCapacityUnits: '5'
+            WriteCapacityUnits: '1'
+        - IndexName: footballRumoursTimeUTC-ID-index
+          KeySchema:
+            - AttributeName: footballRumoursTimeUTC
+              KeyType: HASH
+            - AttributeName: ID
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+          ProvisionedThroughput:
+            ReadCapacityUnits: '2'
             WriteCapacityUnits: '1'
       ProvisionedThroughput:
         ReadCapacityUnits: '5'

--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -14,4 +14,5 @@ case class User(ID: String,
                 contentOffset: Option[Int] = None,
                 contentType: Option[String] = None,
                 daysUncontactable: Option[Int] = None,
-                footballTransfers: Option[Boolean] = None)
+                footballTransfers: Option[Boolean] = None,
+                footballRumoursTimeUTC: Option[String] = None)


### PR DESCRIPTION
As well as transfer notifications by team, users will get a daily link to the "Rumour Mill" series. This will go out at midday in the user's timezone. This time will be stored in a new field in the dynamodb users table - `footballRumoursTimeUTC`.

A lambda will check for users who are due to receive their notification using this field.