### PR TITLE
Transfer rumour notifications

### DIFF
--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -54,6 +54,9 @@ Parameters:
     FootballTransfersSnsTopicArn:
         Description: ARN of the football transfers SNS topic
         Type: String
+    FootballRumoursSnsTopicArn:
+        Description: ARN of the football transfer rumours SNS topic
+        Type: String
 
 Mappings:
     StageMap:
@@ -205,6 +208,7 @@ Resources:
                       Resource:
                           - !GetAtt MorningBriefingSQS.Arn
                           - !GetAtt FootballTransfersSQS.Arn
+                          - !GetAtt FootballRumoursSQS.Arn
             Roles:
                 - !Ref FacebookNewsBotRole
 
@@ -241,6 +245,23 @@ Resources:
                       Condition:
                           ArnEquals:
                               aws:SourceArn: !Ref FootballTransfersSnsTopicArn
+
+    FootballRumoursSQSPolicy:
+        Type: AWS::SQS::QueuePolicy
+        Properties:
+            Queues:
+                - !Ref FootballRumoursSQS
+            PolicyDocument:
+                Statement:
+                    - Sid: allow-sqs-sendmessage
+                      Effect: Allow
+                      Principal:
+                          AWS: "*"
+                      Action: SQS:SendMessage
+                      Resource: !GetAtt FootballRumoursSQS.Arn
+                      Condition:
+                          ArnEquals:
+                              aws:SourceArn: !Ref FootballRumoursSnsTopicArn
 
     InstanceProfile:
         Type: AWS::IAM::InstanceProfile
@@ -389,6 +410,11 @@ Resources:
         Type: AWS::SQS::Queue
         Properties:
             QueueName: !Sub facebook-news-bot-football-transfers-${Stage}
+
+    FootballRumoursSQS:
+        Type: AWS::SQS::Queue
+        Properties:
+            QueueName: !Sub facebook-news-bot-football-rumours-${Stage}
 
     LaunchConfiguration:
         Type: AWS::AutoScaling::LaunchConfiguration

--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -60,6 +60,7 @@ object BotConfig {
     val api = getMandatoryString("football.sheetsApi")
     val transfersSQSName = getMandatoryString("football.transfersSQSName")
     val defaultImageUrl = getMandatoryString("football.defaultImageUrl")
+    val rumoursSQSName = getMandatoryString("football.rumoursSQSName")
   }
 
   val nextGenApiUrl = {

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import com.gu.cm.Mode
 import com.gu.facebook_news_bot.briefing.MorningBriefingPoller
-import com.gu.facebook_news_bot.football_transfers.FootballTransfersPoller
+import com.gu.facebook_news_bot.football_transfers.{FootballTransferRumoursPoller, FootballTransfersPoller}
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, CapiImpl, Facebook, FacebookImpl}
 import de.heikoseeberger.akkahttpcirce.CirceSupport
@@ -181,6 +181,10 @@ object Bot extends App with BotService {
 
   val transfersPoller = PartialFunction.condOpt(BotConfig.football.enabled) {
     case true => system.actorOf(FootballTransfersPoller.props(facebook))
+  }
+  
+  val rumoursPoller = PartialFunction.condOpt(BotConfig.football.enabled) {
+    case true => system.actorOf(FootballTransferRumoursPoller.props(facebook, capi))
   }
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)

--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfer.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfer.scala
@@ -11,3 +11,5 @@ case class FootballTransfer(
    fee: Option[Int])
 
 case class UserFootballTransfer(userId: String, transfer: FootballTransfer)
+
+case class UserFootballTransferRumour(userId: String, articleId: String)

--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransferRumoursPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransferRumoursPoller.scala
@@ -1,0 +1,102 @@
+package com.gu.facebook_news_bot.football_transfers
+
+import java.util.concurrent.TimeUnit
+
+import akka.actor.Props
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.models.{Id, MessageToFacebook}
+import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
+import com.gu.facebook_news_bot.services.{Capi, Facebook, FacebookEvents, SQSMessageBody}
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
+import com.gu.facebook_news_bot.utils.{FacebookMessageBuilder, JsonHelpers, SQSPoller}
+import com.gu.facebook_news_bot.utils.Loggers._
+import com.gu.facebook_news_bot.football_transfers.FootballTransferRumoursPoller._
+import org.jsoup.Jsoup
+import io.circe.generic.auto._
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+/**
+  * Polls SQS for users who should have the latest 'Rumour Mill' article sent to them.
+  * Note that the lambda (facebook-news-bot-football-rumours) decides which article to send,
+  * and whether an article is fresh (newer than 24 hours).
+  */
+
+class FootballTransferRumoursPoller(val facebook: Facebook, val capi: Capi) extends SQSPoller {
+  val SQSName = BotConfig.football.rumoursSQSName
+  override val PollPeriod = 2000.millis
+
+  protected def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] = {
+    JsonHelpers.decodeJson[UserFootballTransferRumour](messageBody.Message).map(processRumour) getOrElse Future.successful(Nil)
+  }
+
+  private def processRumour(rumour: UserFootballTransferRumour): Future[List[FacebookMessageResult]] = {
+    val futureMaybeMessage: Future[Option[MessageToFacebook.Message]] = FootballTransferRumoursCache.get(rumour.articleId).map(m => Future.successful(Some(m)))
+      .getOrElse {
+        //Not already cached - get the article from CAPI and build a message
+        capi.getArticle(rumour.articleId) map { maybeContent =>
+          val maybeMessage = maybeContent.map { content =>
+            val message = buildRumourMessage(content)
+            FootballTransferRumoursCache.put(rumour.articleId, message)
+            message
+          }
+          maybeMessage
+        }
+      }
+
+    futureMaybeMessage.flatMap {
+      case Some(message) =>
+        logNotification(rumour.userId, rumour.articleId)
+        facebook.send(List(MessageToFacebook(recipient = Id(rumour.userId), message = Some(message))))
+      case None =>
+        Future.successful(Nil)
+    }
+  }
+}
+
+object FootballTransferRumoursPoller {
+  def props(facebook: Facebook, capi: Capi) = Props(new FootballTransferRumoursPoller(facebook, capi))
+
+  case class NotificationEventLog(id: String, event: String = "football-transfer-rumour-notification", _eventName: String = "football-transfer-rumour-notification", articleId: String) extends LogEvent
+
+  def logNotification(userId: String, articleId: String): Unit = {
+    val eventLog = NotificationEventLog(id = userId, articleId = articleId)
+    logEvent(JsonHelpers.encodeJson(eventLog))
+    FacebookEvents.logEvent(eventLog)
+  }
+
+  private def buildRumourMessage(content: Content): MessageToFacebook.Message = {
+    val element = MessageToFacebook.Element(
+      title = content.webTitle,
+      item_url = Some(s"${content.webUrl}?CMP=${BotConfig.campaignCode}"),
+      subtitle = content.fields.flatMap(_.standfirst.map(Jsoup.parse(_).text)),
+      image_url = Some(FacebookMessageBuilder.getImageUrl(content)),
+      buttons = Some(List(
+        MessageToFacebook.Button(`type` = "element_share"),
+        MessageToFacebook.Button(
+          `type` = "web_url",
+          url = Some(s"${BotConfig.football.interactiveUrl}?CMP=${BotConfig.campaignCode}"),
+          title = Some("Latest transfers")
+        )
+      ))
+    )
+
+    MessageToFacebook.Message(
+      attachment = Some(MessageToFacebook.Attachment.genericAttachment(List(element)))
+    )
+  }
+}
+
+object FootballTransferRumoursCache {
+  private val CacheExpireHours = 24
+
+  private val cache = Caffeine.newBuilder()
+    .expireAfterWrite(CacheExpireHours, TimeUnit.HOURS)
+    .build[String, MessageToFacebook.Message]()
+
+  def get(articleId: String): Option[MessageToFacebook.Message] = Option(cache.getIfPresent(articleId))
+  def put(articleId: String, message: MessageToFacebook.Message): Unit = cache.put(articleId, message)
+}

--- a/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
@@ -16,6 +16,8 @@ trait Capi {
   def getHeadlines(edition: String, topic: Option[Topic]): Future[Seq[Content]]
 
   def getMostViewed(edition: String, topic: Option[Topic]): Future[Seq[Content]]
+
+  def getArticle(id: String): Future[Option[Content]]
 }
 
 object CapiImpl extends Capi {
@@ -27,6 +29,13 @@ object CapiImpl extends Capi {
 
   def getMostViewed(edition: String, topic: Option[Topic]): Future[Seq[Content]] =
     doQuery(basicItemQuery(topic.map(_.getPath(edition)).getOrElse(edition)).showMostViewed(), _.mostViewed)
+
+  def getArticle(id: String): Future[Option[Content]] = {
+    val query = ItemQuery(id).showFields("standfirst").showElements("image")
+    client.getResponse(query) map { response =>
+      response.content
+    }
+  }
 
   private def doQuery(query: ItemQuery, getResults: (ItemResponse => Option[Seq[Content]])): Future[Seq[Content]] = {
     CapiCache.get(query.toString).map(cached => Future.successful(cached)).getOrElse {

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -64,7 +64,7 @@ object FacebookMessageBuilder {
     s"$webUrl?CMP=${BotConfig.campaignCode}${variant.map(v => s"&variant=$v").getOrElse("")}"
 
   // Look for widest image up to MaxImageWidth
-  private def getImageUrl(content: Content): String = {
+  def getImageUrl(content: Content): String = {
     val widestImageAsset = for {
       elements <- content.elements
       mainElement <- elements.find(_.relation == "main").orElse(elements.headOption)

--- a/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
@@ -17,6 +17,8 @@ object DummyCapi extends Capi {
     getFromFile("mostviewed", edition, topic)
   }
 
+  def getArticle(id: String): Future[Option[Content]] = Future.successful(None)
+
   private def getFromFile(`type`: String, edition: String, topic: Option[Topic]): Future[Seq[Content]] = {
     val file = s"src/test/resources/capiResponses/${`type`}-${topic.map(_.getPath(edition).replace("/","-")).getOrElse(edition)}.json"
     val result = JsonHelpers.decodeFromFile[Seq[Content]](file)


### PR DESCRIPTION
Subscribers will get the latest edition of 'Rumour Mill' each day. 
The lambda (facebook-news-bot-football-rumours) decides who to send to and when, and also whether an article is fresh (newer than 24 hours old).
The 'Latest transfers' link goes to the interactive article.

![picture 12](https://cloud.githubusercontent.com/assets/1513454/21424050/291d666a-c838-11e6-82e0-e7a2c3a27f1b.png)
