### PR TITLE
Advertise football transfers notifications

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
@@ -30,6 +30,8 @@ object FootballTransferStates {
   case object InitialQuestionState extends YesOrNoState {
     val Name = "FOOTBALL_TRANSFER_INITIAL_QUESTION"
 
+    private case class NoEvent(id: String, event: String = "football_transfers_subscribe_no", _eventName: String = "football_transfers_subscribe_no") extends LogEvent
+
     val Question = "Would you like to receive team updates and rumours during the January football transfer window?"
     protected def getQuestionText(user: User) = {
       if (user.version.contains(0)) s"Hi, I'm the Guardian chatbot. $Question"
@@ -38,7 +40,10 @@ object FootballTransferStates {
 
     protected def yes(user: User, facebook: Facebook): Future[Result] = EnterTeamsState.question(user)
 
-    protected def no(user: User): Future[Result] = MainState.menu(user, "Ok. Is there anything else I can help you with?")
+    protected def no(user: User): Future[Result] = {
+      State.log(NoEvent(id = user.ID))
+      MainState.menu(user, "Ok. Is there anything else I can help you with?")
+    }
   }
 
   /**

--- a/src/test/scala/com/gu/facebook_news_bot/FootballTransfersSubscriptionTest.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/FootballTransfersSubscriptionTest.scala
@@ -11,7 +11,7 @@ import org.scalatest.{FunSpec, Matchers}
 import org.scalatest.mockito.MockitoSugar
 import io.circe.generic.auto._
 
-class FootballTransfersTest extends FunSpec with Matchers with ScalatestRouteTest with MockitoSugar with CirceSupport {
+class FootballTransfersSubscriptionTest extends FunSpec with Matchers with ScalatestRouteTest with MockitoSugar with CirceSupport {
   val TestName = "football_transfers_test"
   LocalDynamoDB.createUsersTable(TestName)
   LocalDynamoDB.createUserTeamTable(s"$TestName-teams")


### PR DESCRIPTION
On the 1st January ask all users if they'd like to subscribe to football transfers notifications immediately after their morning briefing (if they're not already subscribed).

Also in this PR:
- make `Facebook.send(messages)` send the next message only after receiving a response from FB. This doesn't necessarily guarantee delivery order, but it seems reliable so far.
- log when people say "no" to the subscription question.

![picture 3](https://cloud.githubusercontent.com/assets/1513454/21428578/9f1e6912-c852-11e6-8c8d-7394ceb944ee.png)
