### PR TITLE
Use fromClub crest if no toClub crest available

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
@@ -46,8 +46,10 @@ object FootballTransfersPoller {
     else s"£$fee"
   }
 
-  private def getImageUrl(name: String): String = {
-    FootballTransferStates.teams.get(name.toLowerCase).flatMap(_.imageUrl)
+  private def getImageUrl(transfer: FootballTransfer): String = {
+    FootballTransferStates.teams.get(transfer.toClub.toLowerCase)
+      .orElse(FootballTransferStates.teams.get(transfer.fromClub.toLowerCase))
+      .flatMap(_.imageUrl)
       .getOrElse(BotConfig.football.defaultImageUrl)
   }
 
@@ -85,7 +87,7 @@ object FootballTransfersPoller {
       url = Some(s"${BotConfig.football.interactiveUrl}?CMP=${BotConfig.campaignCode}"),
       title = Some("See more transfers")
     )
-    val imageUrl = getImageUrl(userFootballTransfer.transfer.toClub)
+    val imageUrl = getImageUrl(userFootballTransfer.transfer)
 
     val attachment = MessageToFacebook.Attachment.genericAttachment(Seq(
       MessageToFacebook.Element(


### PR DESCRIPTION
Currently the app uses the crest of the club the player is going to, but if we don't have a crest for that club then it falls back on a default image.

This happens a lot, e.g. a player going out on loan to a smaller club. I think it's better to fall back on the crest of the club they're coming from.

E.g.
<img width="313" alt="picture 10" src="https://cloud.githubusercontent.com/assets/1513454/21606522/fe3e43fa-d1a7-11e6-86c4-f50908808fd9.png">
