### PR TITLE
Change subscription settings flow

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
@@ -38,9 +38,13 @@ case object BriefingTimeQuestionState extends State {
   }
 
   //Ask the user what time they'd like the briefing
-  def question(user: User): Future[Result] = {
+  def question(user: User, initialMessage: Option[String] = None): Future[Result] = {
     val replies = ValidTimes.map(t => MessageToFacebook.QuickReply("text", Some(s"${t}am"), Some(s"$t")))
-    val message = MessageToFacebook.quickRepliesMessage(user.ID, replies, ResponseText.briefingTimeQuestion)
+    val message = MessageToFacebook.quickRepliesMessage(
+      user.ID,
+      replies,
+      s"${initialMessage.map(msg => s"$msg.\n\n").getOrElse("")}${ResponseText.briefingTimeQuestion}"
+    )
     Future.successful((State.changeState(user, Name), List(message)))
   }
 

--- a/src/main/scala/com/gu/facebook_news_bot/state/EditionQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/EditionQuestionState.scala
@@ -60,8 +60,17 @@ case object EditionQuestionState extends State {
 
   private def success(user: User, edition: String): Future[Result] = {
     State.log(EditionEvent(id = user.ID, edition = edition))
-    val response = MessageToFacebook.textMessage(user.ID, ResponseText.editionChanged(frontToUserFriendly(edition)))
-    val updatedUser = user.copy(state = Some(MainState.Name), front = edition)
-    Future.successful((updatedUser, List(response)))
+
+    if (user.notificationTimeUTC == "-") {
+      //New subscription
+      BriefingTimeQuestionState.question(
+        user.copy(front = edition),
+        Some(ResponseText.editionChanged(frontToUserFriendly(edition)))
+      )
+    } else {
+      val response = MessageToFacebook.textMessage(user.ID, ResponseText.editionChanged(frontToUserFriendly(edition)))
+      val updatedUser = user.copy(state = Some(MainState.Name), front = edition)
+      Future.successful((updatedUser, List(response)))
+    }
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
@@ -13,7 +13,6 @@ import com.gu.facebook_news_bot.state.StateHandler.Result
 import com.gu.facebook_news_bot.state.Teams.TeamData
 import com.gu.facebook_news_bot.stores.UserStore
 import com.gu.facebook_news_bot.utils.Loggers.{LogEvent, appLogger}
-import com.gu.facebook_news_bot.utils.ResponseText
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -151,7 +150,7 @@ object FootballTransferStates {
       result.recoverWith { case _ => InitialQuestionState.question(user) }
     }
 
-    private def unsubscribe(user: User, store: UserStore): Future[Result] = {
+    def unsubscribe(user: User, store: UserStore): Future[Result] = {
       store.getTeams(user.ID).map { currentTeams =>
         currentTeams.foreach(store.removeTeam(user.ID, _))
 

--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -17,7 +17,6 @@ case object MainState extends State {
   val Name = "MAIN"
 
   private case class ContentLogEvent(id: String, event: String, _eventName: String, topic: String, offset: Int) extends LogEvent
-  private case class UnsubscribeLogEvent(id: String, event: String = "unsubscribe", _eventName: String = "unsubscribe") extends LogEvent
 
   private object Patterns {
     val headlines = """(^|\W)(headlines|news)($|\W)""".r.unanchored
@@ -112,7 +111,7 @@ case object MainState extends State {
       case MenuEvent(text) => Some(menu(user, text))
       case ManageSubscriptionEvent => Some(manageSubscriptions(user))
       case SubscribeYesEvent => Some(EditionQuestionState.question(user))
-      case UnsubscribeEvent => Some(unsubscribe(user))
+      case UnsubscribeEvent => Some(UnsubscribeState.question(user))
       case ChangeEditionEvent => Some(EditionQuestionState.question(user))
       case SuggestEvent => Some(suggest(user))
       case ThanksEvent => Some(thanksResponse(user))
@@ -223,17 +222,6 @@ case object MainState extends State {
       "Which subscription would you like to manage?"
     )
     Future.successful((user, List(message)))
-  }
-
-  def unsubscribe(user: User): Future[Result] = {
-    State.log(UnsubscribeLogEvent(user.ID))
-
-    val updatedUser = user.copy(
-      notificationTime = "-",
-      notificationTimeUTC = "-"
-    )
-    val response = MessageToFacebook.textMessage(user.ID, ResponseText.unsubscribe)
-    Future.successful((updatedUser, List(response)))
   }
 
   private def suggest(user: User): Future[Result] = {

--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -111,7 +111,7 @@ case object MainState extends State {
       case GreetingEvent => Some(State.greeting(user))
       case MenuEvent(text) => Some(menu(user, text))
       case ManageSubscriptionEvent => Some(manageSubscriptions(user))
-      case SubscribeYesEvent => Some(BriefingTimeQuestionState.question(user))
+      case SubscribeYesEvent => Some(EditionQuestionState.question(user))
       case UnsubscribeEvent => Some(unsubscribe(user))
       case ChangeEditionEvent => Some(EditionQuestionState.question(user))
       case SuggestEvent => Some(suggest(user))

--- a/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
@@ -90,6 +90,7 @@ class StateHandler(facebook: Facebook, capi: Capi, store: UserStore) {
     case FootballTransferStates.EnterTeamsState.Name => FootballTransferStates.EnterTeamsState
     case FootballTransferStates.ManageFootballTransfersState.Name => FootballTransferStates.ManageFootballTransfersState
     case FootballTransferStates.RemoveTeamState.Name => FootballTransferStates.RemoveTeamState
+    case UnsubscribeState.Name => UnsubscribeState
     case _ => MainState
   }
 

--- a/src/main/scala/com/gu/facebook_news_bot/state/SubscribeQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/SubscribeQuestionState.scala
@@ -24,7 +24,7 @@ case object SubscribeQuestionState extends YesOrNoState {
 
   protected def yes(user: User, facebook: Facebook): Future[Result] = {
     State.log(SubscribeYesEvent(user.ID))
-    BriefingTimeQuestionState.question(user)
+    EditionQuestionState.question(user)
   }
 
   protected def no(user: User): Future[Result] = {

--- a/src/main/scala/com/gu/facebook_news_bot/state/UnsubscribeState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/UnsubscribeState.scala
@@ -1,0 +1,62 @@
+package com.gu.facebook_news_bot.state
+
+import com.gu.facebook_news_bot.models.{Id, MessageFromFacebook, MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook}
+import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.ResponseText
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+case object UnsubscribeState extends State {
+  val Name = "UNSUBSCRIBE_STATE"
+
+  private object Patterns {
+    val morningBriefing = """(^|\W)(morning|briefing)($|\W)""".r.unanchored
+    val footballTransfers = """(^|\W)(football|transfers)($|\W)""".r.unanchored
+    val all = """(^|\W)all($|\W)""".r.unanchored
+    val cancel = """(^|\W)(cancel|none|no)($|\W)""".r.unanchored
+  }
+
+  def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
+    val result: Option[Future[Result]] = State.getUserInput(messaging).map(_.toLowerCase) map {
+      case Patterns.morningBriefing(_,_,_) => ManageMorningBriefingState.unsubscribe(user)
+      case Patterns.footballTransfers(_,_,_) => FootballTransferStates.ManageFootballTransfersState.unsubscribe(user, store)
+      case Patterns.all(_,_) =>
+        for {
+          (updated1, _) <- ManageMorningBriefingState.unsubscribe(user)
+          (updated2, _) <- FootballTransferStates.ManageFootballTransfersState.unsubscribe(updated1, store)
+        } yield {
+          val message = MessageToFacebook.textMessage(user.ID, "Done.\n\nYou can re-subscribe at any time from the menu")
+          (State.changeState(updated2, MainState.Name), List(message))
+        }
+      case Patterns.cancel(_,_,_) => MainState.menu(user, ResponseText.menu)
+      case _ => question(user)
+    }
+
+    result getOrElse question(user)
+  }
+
+  def question(user: User): Future[Result] = {
+    val briefing = if (user.notificationTime != "-") Some(MessageToFacebook.QuickReply("text", Some("Morning briefing"), Some("morning"))) else None
+    val transfers = if (user.footballTransfers.contains(true)) Some(MessageToFacebook.QuickReply("text", Some("Football transfers"), Some("transfers"))) else None
+
+    val quickReplies = List(
+      briefing,
+      transfers,
+      Some(MessageToFacebook.QuickReply("text", Some("All"), Some("all"))),
+      Some(MessageToFacebook.QuickReply("text", Some("Cancel"), Some("cancel")))
+    ).flatten
+
+    val message = MessageToFacebook.Message(
+      text = Some("Which service would you like to unsubscribe from?"),
+      quick_replies = Some(quickReplies)
+    )
+    val response = MessageToFacebook(
+      recipient = Id(user.ID),
+      message = Some(message)
+    )
+    Future.successful(State.changeState(user, Name), List(response))
+  }
+}

--- a/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
@@ -46,7 +46,7 @@ object ResponseText {
 
   def editionQuestion = "Please choose an edition. You can choose from UK, US, Australia or International."
 
-  def editionChanged(edition: String) = s"Your edition has been updated to $edition"
+  def editionChanged(edition: String) = s"Your edition has been set to $edition"
 
   def morningBriefing = random(List(
     "Good morning! Here are the top stories today",

--- a/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/ResponseText.scala
@@ -44,7 +44,7 @@ object ResponseText {
 
   def manageSubscription(edition: String, time: String) = s"Your edition is currently set to $edition and your morning briefing time is $time.\n\nWhat would you like to change?"
 
-  def editionQuestion = "Please choose a new edition:"
+  def editionQuestion = "Please choose an edition. You can choose from UK, US, Australia or International."
 
   def editionChanged(edition: String) = s"Your edition has been updated to $edition"
 

--- a/src/test/resources/facebookRequests/unsubscribeMenu.json
+++ b/src/test/resources/facebookRequests/unsubscribeMenu.json
@@ -9,13 +9,11 @@
             "id" : "subscription_test"
           },
           "recipient" : {
-            "id" : "1"
+            "id" : "3"
           },
           "timestamp" : 0,
-          "message" : {
-            "mid" : "",
-            "seq" : 0,
-            "text" : "morning briefing"
+          "postback" : {
+            "payload" : "unsubscribe"
           }
         }
       ]

--- a/src/test/resources/facebookResponses/changeFront.json
+++ b/src/test/resources/facebookResponses/changeFront.json
@@ -3,6 +3,23 @@
     "id":"subscription_test"
   },
   "message":{
-    "text":"Your edition has been updated to UK"
+    "text":"Your edition has been set to UK.\n\nWhen would you like your morning briefing delivered? You can choose from 6, 7 or 8am.",
+    "quick_replies":[
+      {
+        "content_type":"text",
+        "title":"6am",
+        "payload":"6"
+      },
+      {
+        "content_type":"text",
+        "title":"7am",
+        "payload":"7"
+      },
+      {
+        "content_type":"text",
+        "title":"8am",
+        "payload":"8"
+      }
+    ]
   }
 }

--- a/src/test/resources/facebookResponses/unsubscribeMenu.json
+++ b/src/test/resources/facebookResponses/unsubscribeMenu.json
@@ -1,0 +1,25 @@
+{
+  "recipient":{
+    "id":"subscription_test"
+  },
+  "message":{
+    "text":"Which service would you like to unsubscribe from?",
+    "quick_replies":[
+      {
+        "content_type":"text",
+        "title":"Morning briefing",
+        "payload":"morning"
+      },
+      {
+        "content_type":"text",
+        "title":"All",
+        "payload":"all"
+      },
+      {
+        "content_type":"text",
+        "title":"Cancel",
+        "payload":"cancel"
+      }
+    ]
+  }
+}

--- a/src/test/resources/facebookResponses/yesSubscribe.json
+++ b/src/test/resources/facebookResponses/yesSubscribe.json
@@ -3,22 +3,27 @@
     "id":"subscription_test"
   },
   "message":{
-    "text":"When would you like your morning briefing delivered? You can choose from 6, 7 or 8am.",
+    "text":"Please choose an edition. You can choose from UK, US, Australia or International.",
     "quick_replies":[
       {
         "content_type":"text",
-        "title":"6am",
-        "payload":"6"
+        "title":"UK",
+        "payload":"uk"
       },
       {
         "content_type":"text",
-        "title":"7am",
-        "payload":"7"
+        "title":"US",
+        "payload":"us"
       },
       {
         "content_type":"text",
-        "title":"8am",
-        "payload":"8"
+        "title":"Australian",
+        "payload":"au"
+      },
+      {
+        "content_type":"text",
+        "title":"International",
+        "payload":"international"
       }
     ]
   }

--- a/src/test/scala/com/gu/facebook_news_bot/SubscriptionTest.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/SubscriptionTest.scala
@@ -15,87 +15,64 @@ class SubscriptionTest extends FunSpec with Matchers with ScalatestRouteTest wit
   val TestName = "subscription_test"
   LocalDynamoDB.createUsersTable(TestName)
 
-  it("should ask a new user if they want to subscribe") {
+  private def routeTest(inputFile: String, outputFile: String) = {
     val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/newUser.json"))
+    val request = service.getRequest(loadFile(inputFile))
 
     request ~> service.routes ~> check {
       status should equal(OK)
 
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/newUser.json")
+      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook](outputFile)
       verify(service.facebook, timeout(5000)).send(List(expectedMessage))
     }
   }
 
-  it("should ask what time if user says yes") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/yesSubscribe.json"))
+  it("should ask a new user if they want to subscribe") {
+    routeTest(
+      "src/test/resources/facebookRequests/newUser.json",
+      "src/test/resources/facebookResponses/newUser.json"
+    )
+  }
 
-    request ~> service.routes ~> check {
-      status should equal(OK)
+  it("should ask which edition if user says yes") {
+    routeTest(
+      "src/test/resources/facebookRequests/yesSubscribe.json",
+      "src/test/resources/facebookResponses/yesSubscribe.json"
+    )
+  }
 
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/yesSubscribe.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
+  it("should ask what time after setting edition") {
+    routeTest(
+      "src/test/resources/facebookRequests/changeFront.json",
+      "src/test/resources/facebookResponses/changeFront.json"
+    )
   }
 
   it("should respond to time of 6") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/briefingTime.json"))
-
-    request ~> service.routes ~> check {
-      status should equal(OK)
-
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/briefingTime.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
+    routeTest(
+      "src/test/resources/facebookRequests/briefingTime.json",
+      "src/test/resources/facebookResponses/briefingTime.json"
+    )
   }
 
   it("should include subscription time in response to manage_morning_briefing") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/manageMorningBriefing.json"))
-
-    request ~> service.routes ~> check {
-      status should equal(OK)
-
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/manageMorningBriefing.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
+    routeTest(
+      "src/test/resources/facebookRequests/manageMorningBriefing.json",
+      "src/test/resources/facebookResponses/manageMorningBriefing.json"
+    )
   }
 
-  it("should list editions in response to change_front_menu") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/changeFrontMenu.json"))
-
-    request ~> service.routes ~> check {
-      status should equal(OK)
-
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/changeFrontMenu.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
-  }
-
-  it("should update front") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/changeFront.json"))
-
-    request ~> service.routes ~> check {
-      status should equal(OK)
-
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/changeFront.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
+  it("should display unsubscribe menu") {
+    routeTest(
+      "src/test/resources/facebookRequests/unsubscribeMenu.json",
+      "src/test/resources/facebookResponses/unsubscribeMenu.json"
+    )
   }
 
   it("should unsubscribe") {
-    val service = new TestService(TestName)
-    val request = service.getRequest(loadFile("src/test/resources/facebookRequests/unsubscribe.json"))
-
-    request ~> service.routes ~> check {
-      status should equal(OK)
-
-      val expectedMessage = JsonHelpers.decodeFromFile[MessageToFacebook]("src/test/resources/facebookResponses/unsubscribe.json")
-      verify(service.facebook, timeout(5000)).send(List(expectedMessage))
-    }
+    routeTest(
+      "src/test/resources/facebookRequests/unsubscribe.json",
+      "src/test/resources/facebookResponses/unsubscribe.json"
+    )
   }
 }


### PR DESCRIPTION
1. Ask which edition a user wants while subscribing to the morning briefing. Previously the edition could only be set from the subscriptions menu, which isn't obvious.
![picture 11](https://cloud.githubusercontent.com/assets/1513454/21613197/26cb7d5a-d1cc-11e6-9200-ee5b84d5b02e.png)


2. Handle unsubscribe requests better. Previously saying "unsubscribe" out of context would unsubscribe from the morning briefing. Now it asks the user which service to unsubscribe from, based on their current subscriptions.
![picture 12](https://cloud.githubusercontent.com/assets/1513454/21613288/86c1a568-d1cc-11e6-85bd-4eef65b016fc.png)