### PR TITLE
Greet existing user on referral

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -69,7 +69,10 @@ case object MainState extends State {
       event <- processMessage(message)
     } yield processEvent(user, event, capi, facebook, store)
 
-    result.getOrElse(State.unknown(user))
+    result.getOrElse {
+      if (messaging.referral.nonEmpty) State.greeting(user)
+      else State.unknown(user)
+    }
   }
 
   //Clicking a menu button brings the user into the MAIN state - other states can call this after receiving a postback


### PR DESCRIPTION
E.g. when an existing user clicks the Messenger link in an Instant Article.
Currently it says "Sorry, I didn't understand that" etc.
It should just greet them.