### PR TITLE
Fix handling of 'released' players

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersPoller.scala
@@ -70,7 +70,7 @@ object FootballTransfersPoller {
 
   private def doneDealTitle(t: FootballTransfer): String = {
     t.transferType match {
-      case "release" => s"${t.fromClub} has released ${t.player}"
+      case "released" => s"${t.fromClub} have released ${t.player}"
       case "loan ended" => s"${t.player} returns to ${t.toClub} from ${t.fromClub}"
       case "loan" => s"${t.player} has joined ${t.toClub} on loan from ${t.fromClub}"
       case "fee" if t.fee.isDefined =>


### PR DESCRIPTION
The field in the spreadsheet is called `released`.
Also, Editorial _have_ asked for "has" to be changed to "have".

![picture 13](https://cloud.githubusercontent.com/assets/1513454/21681662/11fbacf6-d348-11e6-90fa-b3c628374c4a.png)
