### PR TITLE
Increase FB actor timeout

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/services/Facebook.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Facebook.scala
@@ -109,7 +109,11 @@ class FacebookImpl extends Facebook with CirceSupport {
   implicit val system = ActorSystem("facebook-actor-system")
   implicit val materializer = ActorMaterializer()
 
-  implicit val timeout = Timeout(5.seconds)
+  /**
+    * Wait this long for a response from FB when sending a message.
+    * Note that delays are generally caused by the facebookActor's queue, not the actual http request.
+    */
+  implicit val timeout = Timeout(20.seconds)
 
   /**
     * Use the TimerBasedThrottler actor to rate-limit messages to Facebook messenger


### PR DESCRIPTION
Messages to be sent to facebook are sent to an actor, which maintains a queue of pending http requests.
When a message is given to this actor, the result is expected some time in the future. Recently, the ask request to the actor has occasionally timed out while processing many morning-briefings and transfer rumours simultaneously. The current actor timout of 5 seconds clearly isn't enough at these times.