### PR TITLE
Improve recording of uncontactable users

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -184,7 +184,7 @@ object Bot extends App with BotService {
   }
   
   val rumoursPoller = PartialFunction.condOpt(BotConfig.football.enabled) {
-    case true => system.actorOf(FootballTransferRumoursPoller.props(facebook, capi))
+    case true => system.actorOf(FootballTransferRumoursPoller.props(facebook, capi, userStore))
   }
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)

--- a/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/MorningBriefingPoller.scala
@@ -1,19 +1,17 @@
 package com.gu.facebook_news_bot.briefing
 
 import akka.actor.Props
-import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import com.gu.facebook_news_bot.BotConfig
 import com.gu.facebook_news_bot.briefing.MorningBriefingPoller._
 import com.gu.facebook_news_bot.models.{MessageToFacebook, User}
-import com.gu.facebook_news_bot.services.Facebook.{FacebookMessageResult, GetUserError, GetUserNoDataResponse, GetUserSuccessResponse}
+import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
 import com.gu.facebook_news_bot.services.{Capi, Facebook, FacebookEvents, SQSMessageBody}
-import com.gu.facebook_news_bot.state.{FootballTransferStates, MainState}
+import com.gu.facebook_news_bot.state.MainState
 import com.gu.facebook_news_bot.state.StateHandler._
 import com.gu.facebook_news_bot.stores.UserStore
 import com.gu.facebook_news_bot.utils.Loggers._
-import com.gu.facebook_news_bot.utils.{JsonHelpers, ResponseText, SQSPoller}
+import com.gu.facebook_news_bot.utils.{JsonHelpers, Notifier, ResponseText, SQSPoller}
 import org.joda.time.{DateTime, DateTimeZone}
-import org.joda.time.format.DateTimeFormat
 import io.circe.generic.auto._
 
 import scala.concurrent.Future
@@ -48,58 +46,23 @@ object MorningBriefingPoller {
 class MorningBriefingPoller(val userStore: UserStore, val capi: Capi, val facebook: Facebook) extends SQSPoller {
   val SQSName = BotConfig.aws.morningBriefingSQSName
   
-  override def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] =
-    JsonHelpers.decodeJson[User](messageBody.Message).map(user => processUser(user.ID)) getOrElse Future.successful(Nil)
-
-  private def processUser(userId: String): Future[List[FacebookMessageResult]] = {
-    for {
-      maybeUser <- userStore.getUser(userId)
-      fbResult <- facebook.getUser(userId)
-      result <- maybeUser.map(user => processUserResults(user, fbResult)).getOrElse(Future.successful(Nil))
-    } yield result
-  }
-
-  private def processUserResults(user: User, fbResult: Facebook.GetUserResult) = {
-    fbResult match {
-      case GetUserSuccessResponse(fbUser) =>
-        if (fbUser.timezone == user.offsetHours) {
-          getMorningBriefing(user).flatMap { case (updatedUser, fbMessages) =>
-            updateAndSend(updatedUser, fbMessages)
-          } recover { case error =>
-            appLogger.error(s"Error getting morning briefing for user ${user.ID}: ${error.getMessage}", error)
-            Nil
-          }
-        } else {
-          //User's timezone has changed - fix this now, but don't send briefing
-          val updatedUser = updateNotificationTime(user, fbUser.timezone)
-          updateAndSend(updatedUser, Nil)
+  override def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] = {
+    JsonHelpers.decodeJson[User](messageBody.Message).map { userFromSqs: User =>
+      for {
+        //Get the latest version of the user from dynamodb
+        maybeUser: Option[User] <- Notifier.getUser(userFromSqs.ID, facebook, userStore)
+        result: List[FacebookMessageResult] <- {
+          maybeUser.map { user =>
+            getMessages(user).flatMap { case (updatedUser, messages) =>
+              Notifier.sendAndUpdate(updatedUser, messages, facebook, userStore)
+            }
+          } getOrElse Future.successful(Nil)
         }
-
-      case GetUserNoDataResponse =>
-        /**
-          * Facebook returned a 200 but will not give us the user's data, which generally means they've deleted the conversation.
-          * Mark them as uncontactable
-          */
-        val daysUncontactable = user.daysUncontactable.map(_ + 1).getOrElse(1)
-        userStore.updateUser(user.copy(daysUncontactable = Some(daysUncontactable)))
-        Future.successful(Nil)
-
-      case GetUserError(error) =>
-        appLogger.info(s"Error from Facebook while trying to get data for user ${user.ID}: $error")
-        Future.successful(Nil)
-    }
+      } yield result
+    } getOrElse Future.successful(Nil)
   }
 
-  private def updateNotificationTime(user: User, timezone: Double): User = {
-    val notifyTime = DateTime.parse(user.notificationTime, DateTimeFormat.forPattern("HH:mm"))
-    val notifyTimeUTC = notifyTime.minusMinutes((timezone * 60).toInt)
-    user.copy(
-      notificationTimeUTC = notifyTimeUTC.toString("HH:mm"),
-      offsetHours = timezone
-    )
-  }
-
-  private def getMorningBriefing(user: User): Future[Result] = {
+  private def getMessages(user: User): Future[Result] = {
     appLogger.debug(s"Getting morning briefing for User: $user")
 
     CollectionsBriefing.getBriefing(user).flatMap { maybeBriefing: Option[Result] =>
@@ -115,39 +78,6 @@ class MorningBriefingPoller(val userStore: UserStore, val capi: Capi, val facebo
           (updatedUser, morningMessage(updatedUser) :: messages)
         }
       }
-    }
-  }
-
-  //Update the user in dynamo, then send the messages
-  private def updateAndSend(user: User, messages: List[MessageToFacebook], retry: Int = 0): Future[List[FacebookMessageResult]] = {
-    userStore.updateUser(user.copy(daysUncontactable = Some(0))) flatMap { updateResult =>
-      updateResult.fold(
-        { error: ConditionalCheckFailedException =>
-          //User has since been updated in dynamo, get the latest version and try again
-          if (retry < 3) {
-            userStore.getUser(user.ID).flatMap {
-              case Some(latestUser) =>
-                val mergedUser = user.copy(
-                  //All other fields should come from updatedUser
-                  version = latestUser.version,
-                  front = latestUser.front
-                )
-                updateAndSend(mergedUser, messages, retry+1)
-
-              case None => updateAndSend(user, messages, retry+1)
-            }
-          } else {
-            //Something has gone very wrong
-            appLogger.error(s"Failed to update user state multiple times. User is $user and error is ${error.getMessage}", error)
-            Future.successful(Nil)
-          }
-        }, { _ =>
-          if (messages.nonEmpty) {
-            appLogger.debug(s"Sending morning briefing to ${user.ID}: $messages")
-            facebook.send(messages)
-          } else Future.successful(Nil)
-        }
-      )
     }
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
@@ -25,7 +25,7 @@ object FootballTransferStates {
 
   val teams: Map[String,TeamData] = Teams.getTeams
 
-  private val rumoursNotificationTime = DateTimeFormat.forPattern("HH").parseDateTime("12")
+  val rumoursNotificationTime = DateTimeFormat.forPattern("HH").parseDateTime("12")
 
   case object InitialQuestionState extends YesOrNoState {
     val Name = "FOOTBALL_TRANSFER_INITIAL_QUESTION"

--- a/src/main/scala/com/gu/facebook_news_bot/utils/Notifier.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/Notifier.scala
@@ -1,0 +1,138 @@
+package com.gu.facebook_news_bot.utils
+
+import com.gu.facebook_news_bot.models.{MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.Facebook
+import com.gu.facebook_news_bot.services.Facebook.{FacebookMessageResult, GetUserError, GetUserNoDataResponse, GetUserSuccessResponse}
+import com.gu.facebook_news_bot.state.FootballTransferStates
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.Loggers._
+import org.joda.time.DateTime
+import org.joda.time.format.DateTimeFormat
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+/**
+  * For sending notifications to users.
+  *
+  * Takes care of:
+  * 1. Tracking changing timezones
+  * 2. Recording uncontactable users
+  */
+object Notifier {
+
+  /**
+    * Attempts to get the user's data from both Facebook and dynamodb.
+    * If Facebook doesn't return their data, record the user as uncontactable and return None.
+    * If the user's timezone has changed, update their notification times in dynamodb and return None.
+    */
+  def getUser(userId: String, facebook: Facebook, userStore: UserStore): Future[Option[User]] = {
+    for {
+      maybeUser: Option[User] <- userStore.getUser(userId)
+      fbResult: Facebook.GetUserResult <- facebook.getUser(userId)
+    } yield {
+      maybeUser flatMap { user =>
+        fbResult match {
+          case GetUserSuccessResponse(fbUser) =>
+            if (fbUser.timezone == user.offsetHours) {
+              Some(user)
+            } else {
+              //User's timezone has changed - fix this now, but don't send briefing
+              val updatedUser = changeNotificationTime(user, fbUser.timezone)
+              updateUser(updatedUser, userStore)
+              None
+            }
+
+          case GetUserNoDataResponse =>
+            /**
+              * Facebook returned a 200 but will not give us the user's data, which generally means they've deleted the conversation.
+              * Mark them as uncontactable
+              */
+            updateUser(incrementDaysUncontactable(user), userStore)
+            None
+
+          case GetUserError(error) =>
+            appLogger.info(s"Error from Facebook while trying to get data for user ${user.ID}: $error")
+            None
+        }
+      }
+    }
+  }
+
+  /**
+    * Call this to send a notification to a user and then update their state in dynamodb
+    */
+  def sendAndUpdate(user: User, messages: List[MessageToFacebook], facebook: Facebook, userStore: UserStore): Future[List[FacebookMessageResult]] = {
+    if (messages.nonEmpty) {
+      appLogger.debug(s"Sending notification to ${user.ID}: $messages")
+
+      facebook.send(messages) map { results: List[Facebook.FacebookMessageResult] =>
+        if (!results.contains(Facebook.FacebookMessageSuccess)) {
+          //We were able to get the user's details from FB, but they appear to be uncontactable
+          appLogger.debug(s"Failed to send notification to user $user: $messages")
+          updateUser(incrementDaysUncontactable(user), userStore)
+          results
+        } else {
+          updateUser(user.copy(daysUncontactable = Some(0)), userStore)
+          results
+        }
+      }
+    } else {
+      updateUser(user, userStore)
+      Future.successful(Nil)
+    }
+  }
+
+  private val TimeFormat = DateTimeFormat.forPattern("HH:mm")
+
+  private def changeNotificationTime(user: User, timezone: Double): User = {
+    val newNotificationTimeUTC: String = {
+      if (user.notificationTime != "-") {
+        val notifyTime = DateTime.parse(user.notificationTime, TimeFormat)
+        notifyTime.minusMinutes((timezone * 60).toInt).toString("HH:mm")
+      } else "-"
+    }
+
+    val newFootballRumoursTimeUTC: Option[String] = {
+      if (user.footballTransfers.contains(true)) Some(FootballTransferStates.rumoursNotificationTime.minusMinutes((timezone * 60).toInt).toString("HH:mm"))
+      else None
+    }
+
+    user.copy(
+      notificationTimeUTC = newNotificationTimeUTC,
+      offsetHours = timezone,
+      footballRumoursTimeUTC = newFootballRumoursTimeUTC
+    )
+  }
+
+  private def updateUser(user: User, userStore: UserStore, retry: Int = 0): Unit = {
+    userStore.updateUser(user) foreach { updateResult =>
+      updateResult.swap.toOption.foreach { error =>
+        //User has since been updated in dynamo, get the latest version and try again
+        if (retry < 3) {
+          userStore.getUser(user.ID).foreach {
+            case Some(latestUser) =>
+              val mergedUser = latestUser.copy(
+                //All other fields should come from latestUser
+                state = user.state,
+                offsetHours = user.offsetHours,
+                notificationTime = user.notificationTime,
+                notificationTimeUTC = user.notificationTimeUTC,
+                footballRumoursTimeUTC = user.footballRumoursTimeUTC,
+                daysUncontactable = user.daysUncontactable
+              )
+              updateUser(mergedUser, userStore, retry + 1)
+
+            case None => updateUser(user, userStore, retry + 1)
+          }
+        } else {
+          //Something has gone very wrong
+          appLogger.error(s"Failed to update user state multiple times. User is $user and error is ${error.getMessage}", error)
+        }
+      }
+    }
+  }
+
+  private def incrementDaysUncontactable(user: User): User =
+    user.copy(daysUncontactable = user.daysUncontactable.map(_ + 1).orElse(Some(1)))
+}


### PR DESCRIPTION
We record when users become uncontactable in order to get a true subscriber count.

If a user does not unusubscribe from notifications formally through our bot, they can prevent us from sending messages in one of the followings ways:
1. Delete the conversation - this is the most common. This means we cannot get the user's data from the FB graph api, and we cannot send them messages. We already record this case in dynamodb.
2. Click "Turn off all messages" in the Manage Messages menu. This means we can still get the user's data from FB graph api, but cannot send them messages. We do not currently record this case.

This change does the following:
1. Records when users become uncontactable through the 2nd option above.
2. Moves the notifications logic in `MorningBriefingPoller` to the new `Notifier` object, for use by other types of notifications. Transfer rumours notifications now uses it.