### PR TITLE
Increase autoscaling size to 2

### DIFF
--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -61,9 +61,9 @@ Parameters:
 Mappings:
     StageMap:
         PROD:
-            MinSize: 1
-            MaxSize: 2
-            DesiredCapacity: 1
+            MinSize: 2
+            MaxSize: 4
+            DesiredCapacity: 2
             InstanceType: t2.micro
         CODE:
             MinSize: 1


### PR DESCRIPTION
To
1. reduce delay in sending out morning briefings
2. ensure the bot responds quickly to messages from users