### PR TITLE
Support custom handling of postbacks

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/MainState.scala
@@ -75,7 +75,7 @@ case object MainState extends State {
   }
 
   //Clicking a menu button brings the user into the MAIN state - other states can call this after receiving a postback
-  def onMenuButtonClick(user: User, postback: MessageFromFacebook.Postback, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
+  override def onPostback(user: User, postback: MessageFromFacebook.Postback, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
     val result = processButtonPostback(postback) map { event =>
       processEvent(user, event, capi, facebook, store)
     }

--- a/src/main/scala/com/gu/facebook_news_bot/state/State.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/State.scala
@@ -16,6 +16,13 @@ trait State {
     * Define the user's state transition, and build any messages to be sent to user
     */
   def transition(user: User, message: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result]
+
+  /**
+    * Since buttons persist after the conversation has moved on, we should try to avoid using them for state-specific behaviour.
+    * Where buttons are needed by a state, override this method to define the state transition.
+    */
+  def onPostback(user: User, postback: MessageFromFacebook.Postback, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] =
+    MainState.onPostback(user, postback, capi, facebook, store)
 }
 
 object State {

--- a/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
@@ -80,7 +80,10 @@ class StateHandler(facebook: Facebook, capi: Capi, store: UserStore) {
       postback.referral.flatMap(ref => processReferral(ref, user))
         .orElse(user.state.collect { case StateHandler.NewUserStateName => SubscribeQuestionState.question(user) })
         .getOrElse(State.greeting(user))
-    } else MainState.onMenuButtonClick(user, postback, capi, facebook, store)
+    } else {
+      val state = user.state.map(StateHandler.getStateFromString).getOrElse(MainState)
+      state.onPostback(user, postback, capi, facebook, store)
+    }
   }
 
   /**


### PR DESCRIPTION
In general, the receipt of a `postback` means the user has clicked a button.
It's best to avoid using buttons for behaviour that is specific to a state, as buttons persist after the conversation has moved on, meaning the user can later click a button out of context.

However, for the oscar nominations feature we have a legitimate reason to use buttons - for choosing predictions from a carousel.

So this change makes it possible for a state to override handling of postbacks. By default postbacks will still be handled by the `MAIN` state.