### PR TITLE
Football transfers feedback

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotConfig.scala
@@ -62,6 +62,7 @@ object BotConfig {
     val transfersSQSName = getMandatoryString("football.transfersSQSName")
     val defaultImageUrl = getMandatoryString("football.defaultImageUrl")
     val rumoursSQSName = getMandatoryString("football.rumoursSQSName")
+    val feedbackEnabled = getBoolOrDefault("football.feedbackEnabled", false)
   }
 
   val nextGenApiUrl = {

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -12,7 +12,7 @@ import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException
 import com.gu.cm.Mode
 import com.gu.facebook_news_bot.briefing.MorningBriefingPoller
-import com.gu.facebook_news_bot.football_transfers.{FootballTransferRumoursPoller, FootballTransfersPoller}
+import com.gu.facebook_news_bot.football_transfers.{FootballTransferRumoursPoller, FootballTransfersPoller, FootballTransfersFeedbackPoller}
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, CapiImpl, Facebook, FacebookImpl}
 import de.heikoseeberger.akkahttpcirce.CirceSupport
@@ -187,6 +187,10 @@ object Bot extends App with BotService {
   
   val rumoursPoller = PartialFunction.condOpt(BotConfig.football.enabled) {
     case true => system.actorOf(FootballTransferRumoursPoller.props(facebook, capi, userStore))
+  }
+
+  val footballFeedbackPoller = PartialFunction.condOpt(BotConfig.football.feedbackEnabled) {
+    case true => system.actorOf(FootballTransfersFeedbackPoller.props(facebook, capi, userStore))
   }
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)

--- a/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersFeedbackPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/football_transfers/FootballTransfersFeedbackPoller.scala
@@ -1,0 +1,38 @@
+package com.gu.facebook_news_bot.football_transfers
+
+import akka.actor.Props
+import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.services.Facebook.FacebookMessageResult
+import com.gu.facebook_news_bot.services.{Capi, Facebook, SQSMessageBody}
+import com.gu.facebook_news_bot.state.FootballTransferStates
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.{JsonHelpers, Notifier, SQSPoller}
+import io.circe.generic.auto._
+
+import scala.concurrent.duration._
+import scala.concurrent.Future
+
+object FootballTransfersFeedbackPoller {
+  def props(facebook: Facebook, capi: Capi, userStore: UserStore) = Props(new FootballTransfersFeedbackPoller(facebook, capi, userStore))
+}
+
+class FootballTransfersFeedbackPoller(val facebook: Facebook, val capi: Capi, val userStore: UserStore) extends SQSPoller {
+  val SQSName = BotConfig.football.rumoursSQSName //Use existing infrastructure for this one-off message
+  override val PollPeriod = 2000.millis
+
+  protected def process(messageBody: SQSMessageBody): Future[List[FacebookMessageResult]] = {
+    JsonHelpers.decodeJson[UserFootballTransferRumour](messageBody.Message).map { rumour =>
+      val futureMaybeUser = for {
+        maybeUser <- Notifier.getUser(rumour.userId, facebook, userStore)
+      } yield maybeUser
+
+      futureMaybeUser.flatMap {
+        case Some(user) =>
+          FootballTransferStates.FootballTransfersFeedbackState.question(user) flatMap {
+            case (updatedUser, messages) => Notifier.sendAndUpdate(updatedUser, messages, facebook, userStore)
+          }
+        case None => Future.successful(Nil)
+      }
+    }.getOrElse(Future.successful(Nil))
+  }
+}

--- a/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
@@ -10,10 +10,10 @@ import io.circe.generic.auto._
 
 import scala.concurrent.Future
 
-object FeedbackState extends State {
-  val Name = "FEEDBACK"
+trait FeedbackState extends State {
+  val message: String
 
-  private case class LogFeedback(id: String, event: String = "feedback", _eventName: String = "feedback", feedback: String) extends LogEvent
+  private case class LogFeedback(id: String, event: String = Name.toLowerCase, _eventName: String = Name.toLowerCase, feedback: String) extends LogEvent
 
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
     val result = for {
@@ -28,6 +28,12 @@ object FeedbackState extends State {
   }
 
   def question(user: User): Future[Result] = {
-    Future.successful(State.changeState(user, Name), List(MessageToFacebook.textMessage(user.ID, "How can we improve this service? Type here, and I'll pass it onto the Guardian")))
+    Future.successful(State.changeState(user, Name), List(MessageToFacebook.textMessage(user.ID, message)))
   }
+}
+
+object FeedbackState extends FeedbackState {
+  val Name = "FEEDBACK"
+
+  val message = "How can we improve this service? Type here, and I'll pass it onto the Guardian."
 }

--- a/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
@@ -203,6 +203,11 @@ object FootballTransferStates {
       Future.successful((State.changeState(user, MainState.Name), List(message)))
     }
   }
+
+  case object FootballTransfersFeedbackState extends FeedbackState {
+    val Name = "FOOTBALL_TRANSFERS_FEEDBACK"
+    val message = "Hi. The January transfer window has now closed. The teams in the top five European leagues were involved in 547 transfers for a total value of £651,638,639.\n\nDid you find these notifications useful? Type your feedback here, and I'll pass it onto the Guardian."
+  }
 }
 
 /**

--- a/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
@@ -31,6 +31,7 @@ object StateHandler {
     FootballTransferStates.EnterTeamsState,
     FootballTransferStates.ManageFootballTransfersState,
     FootballTransferStates.RemoveTeamState,
+    FootballTransferStates.FootballTransfersFeedbackState,
     OscarsNomsStates.InitialQuestionState,
     OscarsNomsStates.EnterNomsState,
     UnsubscribeState)

--- a/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/SQSPoller.scala
@@ -10,6 +10,7 @@ import com.gu.facebook_news_bot.services._
 import com.gu.facebook_news_bot.utils.Loggers._
 import com.gu.facebook_news_bot.utils.SQSPoller.Poll
 import io.circe.generic.auto._
+import org.joda.time.{DateTime, DateTimeZone}
 
 import scala.collection.JavaConverters._
 import scala.concurrent.{ExecutionContext, Future}
@@ -18,6 +19,17 @@ import scala.util.{Failure, Success, Try}
 
 object SQSPoller {
   case object Poll
+
+  //Given the UTC offset, is it currently this date?
+  def isDate(offset: Double, date: DateTime): Boolean = {
+    val hours = math.floor(offset).toInt
+    val mins = ((offset * 60) % 60).toInt
+    val now = DateTime.now(DateTimeZone.forOffsetHoursMinutes(hours, mins))
+
+    now.getDayOfMonth == date.getDayOfMonth &&
+      now.getMonthOfYear == date.getMonthOfYear &&
+      now.getYear == date.getYear
+  }
 }
 
 trait SQSPoller extends Actor {


### PR DESCRIPTION
We will send out a one-off message to all football transfers subscribers, to ask for feedback.

- Made `FeedbackState` a trait so that it can be used for feedback on specific things.
- Added a new poller to process these notifications. This uses the existing SQS for the football rumours, as we need to send these out today.

TODO - build a more general way of sending out mass messages to a subset of users like this.