### PR TITLE
Custom briefing pub

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
@@ -1,0 +1,60 @@
+package com.gu.facebook_news_bot.briefing
+
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.facebook_news_bot.models.{Id, MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Topic}
+import com.gu.facebook_news_bot.state.StateHandler._
+import com.gu.facebook_news_bot.utils.FacebookMessageBuilder
+import com.gu.facebook_news_bot.utils.Loggers._
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+object CustomBriefing {
+
+  /**
+    * Returns a morning briefing only if the user has signed up for custom briefings
+    */
+  def getBriefing(user: User, capi: Capi): Option[Future[Result]] = {
+    user.briefingTopic1.map { topic1 =>
+      val futureMaybeCarousel = for {
+        headlines <- capi.getHeadlines(user.front, None)
+        topic1Headlines <- capi.getHeadlines(user.front, Topic.getTopic(topic1))
+        //2nd topic is optional
+        topic2Headlines <- user.briefingTopic2.map(topic2 => capi.getHeadlines(user.front, Topic.getTopic(topic2))).getOrElse(Future.successful(Nil))
+      } yield {
+
+        //Interleave main headlines with topic stories
+        val stories: List[Content] = List(
+          headlines.headOption,
+          topic1Headlines.headOption,
+          headlines.lift(1),
+          topic2Headlines.headOption orElse topic1Headlines.lift(1),
+          headlines.lift(2)
+        ).flatten
+
+        FacebookMessageBuilder.contentToCarousel(
+          contentList = stories,
+          offset = 0,
+          edition = user.front,
+          currentTopic = None,
+          variant = Some(getVariant(user.front)),
+          includeMoreQuickReply = false
+        )
+      }
+
+      futureMaybeCarousel.map { maybeCarousel =>
+        val messages = maybeCarousel.map(carousel => List(MessageToFacebook(Id(user.ID), Some(carousel))))
+          .getOrElse {
+            //If we didn't get a carousel back then it's probably a CAPI issue
+            appLogger.warn(s"Failed to build custom briefing carousel for user: ${user.ID}")
+            Nil
+          }
+
+        (user, messages)
+      }
+    }
+  }
+
+  def getVariant(edition: String) = s"custom-briefing-$edition"
+}

--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -17,4 +17,6 @@ case class User(ID: String,
                 footballTransfers: Option[Boolean] = None,
                 footballRumoursTimeUTC: Option[String] = None,
                 oscarsNoms: Option[Boolean] = None,
-                oscarsNomsUpdateType: Option[Boolean] = None)
+                oscarsNomsUpdateType: Option[Boolean] = None,
+                briefingTopic1: Option[String] = None,
+                briefingTopic2: Option[String] = None)

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -10,7 +10,7 @@ object FacebookMessageBuilder {
   val MaxImageWidth = 1000
   val CarouselSize = 5  //Number of items in a carousel
 
-  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, currentTopic: Option[String], variant: Option[String] = None): Option[MessageToFacebook.Message] = {
+  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, currentTopic: Option[String], variant: Option[String] = None, includeMoreQuickReply: Boolean = true): Option[MessageToFacebook.Message] = {
     val sliced = contentList.slice(offset, offset + CarouselSize)
     if (sliced.isEmpty) None
     else {
@@ -25,11 +25,21 @@ object FacebookMessageBuilder {
       }
       val attachment = MessageToFacebook.Attachment.genericAttachment(tiles)
 
-      val moreQuickReply = MessageToFacebook.QuickReply(
-        content_type = "text",
-        title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
-        payload = Some("more")
-      )
+      val moreQuickReply = {
+        if (includeMoreQuickReply) {
+          MessageToFacebook.QuickReply(
+            content_type = "text",
+            title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
+            payload = Some("more")
+          )
+        } else {
+          MessageToFacebook.QuickReply(
+            content_type = "text",
+            title = Some("Headlines"),
+            payload = Some("headlines")
+          )
+        }
+      }
 
       Some(MessageToFacebook.Message(
         attachment = Some(attachment),


### PR DESCRIPTION
Support the publication of custom morning briefings. The user can choose 1-2 topics to include in the carousel. The 5 stories in the carousel are picked as follows:
1. editors-picks[0]
2. topic1[0]
3. editors-picks[1]
4. topic2[0] || topic1[1]
5. editors-picks[2]

The urls will end with `&variant=custom-briefing-<edition>`