### PR TITLE
Custom briefing subscription

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/models/User.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/models/User.scala
@@ -17,4 +17,6 @@ case class User(ID: String,
                 footballTransfers: Option[Boolean] = None,
                 footballRumoursTimeUTC: Option[String] = None,
                 oscarsNoms: Option[Boolean] = None,
-                oscarsNomsUpdateType: Option[Boolean] = None)
+                oscarsNomsUpdateType: Option[Boolean] = None,
+                briefingTopic1: Option[String] = None,
+                briefingTopic2: Option[String] = None)

--- a/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
@@ -94,6 +94,7 @@ object Topic {
     SectionTopic("stage"),
     SectionTopic("fashion"),
     SectionTopic("science"),
+    SectionTopic(List("opinion", "comment"), "commentisfree"),
 
     SectionTagTopic(List("rugby","rugby union"), "sport", "rugby-union"),
     SectionTagTopic(List("formula 1","formula one","f1"), "sport", "formulaone"),

--- a/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/BriefingTimeQuestionState.scala
@@ -62,7 +62,7 @@ case object BriefingTimeQuestionState extends State {
           notificationTimeUTC = notifyTimeUTC.toString("HH:mm")
         )
 
-        MainState.menu(updatedUser, ResponseText.subscribed(time))
+        CustomBriefingQuestionState.question(updatedUser)
 
       case other =>
         appLogger.error(s"Failed to get user data for user ${user.ID} while processing briefing time: $other")

--- a/src/main/scala/com/gu/facebook_news_bot/state/CustomBriefingQuestionState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/CustomBriefingQuestionState.scala
@@ -1,0 +1,80 @@
+package com.gu.facebook_news_bot.state
+
+import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook, Topic}
+import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
+import com.gu.facebook_news_bot.utils.ResponseText
+import io.circe.generic.auto._
+
+import scala.concurrent.Future
+
+case object CustomBriefingQuestionState extends State {
+
+  val Name = "CUSTOM_BRIEFING_QUESTION"
+
+  private val topics = List("tech", "science", "opinion", "sport", "football", "film", "music", "food", "fashion", "travel")
+  private val quickReplies: List[MessageToFacebook.QuickReply] = topics.map { topic =>
+    MessageToFacebook.QuickReply(title = Some(topic.capitalize), payload = Some(topic))
+  }
+
+  private case class NoEvent(id: String, event: String = "custom_briefing_no", _eventName: String = "custom_briefing_no") extends LogEvent
+  private case class YesEvent(id: String, event: String = "custom_briefing_yes", _eventName: String = "custom_briefing_yes") extends LogEvent
+  private case class UnkownEvent(id: String, event: String = "custom_briefing_unknown", _eventName: String = "custom_briefing_unknown", text: String) extends LogEvent
+
+  def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
+    State.getUserInput(messaging) match {
+      case Some(text) => parseText(user, store, text)
+      case None => finish(user)
+    }
+  }
+
+  def question(user: User, text: Option[String] = None): Future[Result] = {
+    val questionMessage = buildQuestionMessage(
+      user.ID,
+      text.getOrElse("I can personalise your briefing. Do you want to choose a favourite topic?"),
+      user.briefingTopic1
+    )
+
+    Future.successful(State.changeState(user, Name), List(questionMessage))
+  }
+
+  private def parseText(user: User, store: UserStore, text: String): Future[Result] = {
+    text.toLowerCase match {
+      case State.YesPattern(_) =>
+        Future.successful(State.changeState(user, Name), List(buildQuestionMessage(user.ID, "Ok, which topic?", user.briefingTopic1)))
+
+      case State.NoPattern(_) => finish(user)
+
+      case other =>
+        Topic.getTopic(other).map { topic =>
+          if (user.briefingTopic1.isEmpty) {
+            State.log(YesEvent(user.ID))
+
+            val message = buildQuestionMessage(user.ID, "Ok. Do you have another favourite topic?", user.briefingTopic1)
+            Future.successful(user.copy(briefingTopic1 = Some(topic.name)), List(message))
+          } else {
+            MainState.menu(user.copy(briefingTopic2 = Some(topic.name)), ResponseText.subscribed(user.notificationTime))
+          }
+        } getOrElse {
+          State.log(UnkownEvent(user.ID, text = other))
+          question(user, Some(s"Sorry, I don't know that topic. Are you interested in any of these?"))
+        }
+    }
+  }
+
+  private def finish(user: User): Future[Result] = {
+    if (user.briefingTopic1.isEmpty) State.log(NoEvent(id = user.ID))
+    MainState.menu(user, ResponseText.subscribed(user.notificationTime))
+  }
+
+  private def buildQuestionMessage(id: String, text: String, excludeTopic: Option[String]): MessageToFacebook = {
+    val replies = excludeTopic.map(topic => quickReplies.filterNot(_.payload.contains(topic))).getOrElse(quickReplies)
+    MessageToFacebook.quickRepliesMessage(
+      id = id,
+      quickReplies = replies,
+      text = text
+    )
+  }
+}

--- a/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FootballTransferStates.scala
@@ -55,8 +55,6 @@ object FootballTransferStates {
     */
   case object EnterTeamsState extends State {
     val Name = "FOOTBALL_TRANSFER_ENTER_TEAMS"
-    
-    private val NoPattern = """\b(no|nope|nah|not)\b""".r.unanchored
 
     private case class NewSubscriberEvent(id: String, event: String = "football_transfers_subscribe", _eventName: String = "football_transfers_subscribe", isSubscriber: Boolean) extends LogEvent
 
@@ -74,9 +72,9 @@ object FootballTransferStates {
 
     private def parseText(user: User, store: UserStore, text: String): Future[Result] = {
       text.toLowerCase match {
-        case YesOrNoState.YesPattern(_) => question(user)
+        case State.YesPattern(_) => question(user)
 
-        case NoPattern(_) =>
+        case State.NoPattern(_) =>
           val firstSentence = {
             if (user.footballTransfers.contains(true)) "Thanks for signing up. You’ll receive updates throughout the January window.\n"
             else ""

--- a/src/main/scala/com/gu/facebook_news_bot/state/ManageMorningBriefingState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/ManageMorningBriefingState.scala
@@ -21,6 +21,8 @@ object ManageMorningBriefingState extends State {
       if (lower.contains("time")) Some(BriefingTimeQuestionState.question(user))
       else if (lower.contains("edition")) Some(EditionQuestionState.question(user))
       else if (lower.contains("unsubscribe")) Some(unsubscribe(user))
+      else if (lower.contains("add")) Some(CustomBriefingQuestionState.question(user))
+      else if (lower.contains("remove")) Some(RemoveCustomBriefingTopicState.question(user))
       else None
     } getOrElse State.unknown(user)
   }
@@ -35,9 +37,14 @@ object ManageMorningBriefingState extends State {
         MessageToFacebook.QuickReply(title = Some("Unsubscribe"), payload = Some("unsubscribe"))
       )
 
+      val topicQuickReplies = List(
+        user.briefingTopic1.map( _ => MessageToFacebook.QuickReply(title = Some("Remove topic"), payload = Some("remove"))),
+        if (user.briefingTopic2.isEmpty) Some(MessageToFacebook.QuickReply(title = Some("Add topic"), payload = Some("add"))) else None
+      ).flatten
+
       val message = MessageToFacebook.quickRepliesMessage(
         user.ID,
-        quickReplies,
+        quickReplies ++ topicQuickReplies,
         ResponseText.manageSubscription(EditionQuestionState.frontToUserFriendly(user.front), user.notificationTime)
       )
 
@@ -51,7 +58,9 @@ object ManageMorningBriefingState extends State {
     val updatedUser = user.copy(
       state = Some(MainState.Name),
       notificationTime = "-",
-      notificationTimeUTC = "-"
+      notificationTimeUTC = "-",
+      briefingTopic1 = None,
+      briefingTopic2 = None
     )
     val response = MessageToFacebook.textMessage(user.ID, ResponseText.unsubscribe)
     Future.successful((updatedUser, List(response)))

--- a/src/main/scala/com/gu/facebook_news_bot/state/RemoveCustomBriefingTopicState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/RemoveCustomBriefingTopicState.scala
@@ -1,0 +1,54 @@
+package com.gu.facebook_news_bot.state
+
+import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook}
+import com.gu.facebook_news_bot.state.StateHandler._
+import com.gu.facebook_news_bot.stores.UserStore
+
+import scala.concurrent.Future
+
+object RemoveCustomBriefingTopicState extends State {
+  val Name = "REMOVE_CUSTOM_BRIEFING_TOPIC"
+
+  def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
+    State.getUserInput(messaging).flatMap { text =>
+      val maybeUpdatedUser = updateUserTopics(user, text.toLowerCase)
+      maybeUpdatedUser.map(updatedUser => Future.successful((updatedUser, List(buildMessage(updatedUser.ID, text)))))
+
+    } getOrElse State.unknown(user)
+  }
+
+  def question(user: User): Future[Result] = {
+    val quickReplies = List(user.briefingTopic1, user.briefingTopic2)
+      .flatten
+      .map(topic => MessageToFacebook.QuickReply(title = Some(topic.capitalize), payload = Some(topic)))
+
+    val message = MessageToFacebook.quickRepliesMessage(
+      user.ID,
+      quickReplies = quickReplies,
+      text = "Which topic do you want to remove from your morning briefing?"
+    )
+    Future.successful(State.changeState(user, Name), List(message))
+  }
+
+  private def updateUserTopics(user: User, topic: String): Option[User] = {
+    if (user.briefingTopic1.contains(topic)) {
+      val updatedUser = user.copy(
+        state = Some(MainState.Name),
+        briefingTopic1 = user.briefingTopic2,
+        briefingTopic2 = None
+      )
+      Some(updatedUser)
+
+    } else if (user.briefingTopic2.contains(topic)) {
+      val updatedUser = user.copy(
+        state = Some(MainState.Name),
+        briefingTopic2 = None
+      )
+      Some(updatedUser)
+
+    } else None
+  }
+
+  private def buildMessage(id: String, topic: String) = MessageToFacebook.textMessage(id, s"I've removed $topic from your morning briefing.")
+}

--- a/src/main/scala/com/gu/facebook_news_bot/state/State.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/State.scala
@@ -44,4 +44,7 @@ object State {
     logEvent(json)
     FacebookEvents.logEvent(event)
   }
+
+  val YesPattern = """\b(yes|yeah|yep|sure|ok|okay)\b""".r.unanchored
+  val NoPattern = """\b(no|nope|nah|not)\b""".r.unanchored
 }

--- a/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
@@ -35,6 +35,8 @@ object StateHandler {
     OscarsNomsStates.InitialQuestionState,
     OscarsNomsStates.EnterNomsState,
     OscarsNomsStates.UpdateTypeState,
+    CustomBriefingQuestionState,
+    RemoveCustomBriefingTopicState,
     UnsubscribeState)
     .map((state: State) => (state.Name, state))
     .toMap + (StateHandler.NewUserStateName -> SubscribeQuestionState)

--- a/src/main/scala/com/gu/facebook_news_bot/state/YesOrNoState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/YesOrNoState.scala
@@ -7,13 +7,9 @@ import com.gu.facebook_news_bot.stores.UserStore
 
 import scala.concurrent.Future
 
-object YesOrNoState {
-  val YesPattern = """\b(yes|yeah|yep|sure|ok|okay)\b""".r.unanchored
-}
-
 trait YesOrNoState extends State {
   def transition(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] = {
-    if (State.getUserInput(messaging).exists(s => YesOrNoState.YesPattern.findFirstIn(s.toLowerCase).isDefined)) yes(user, facebook)
+    if (State.getUserInput(messaging).exists(s => State.YesPattern.findFirstIn(s.toLowerCase).isDefined)) yes(user, facebook)
     else no(user)
   }
 

--- a/src/test/resources/facebookRequests/customBriefingTopic.json
+++ b/src/test/resources/facebookRequests/customBriefingTopic.json
@@ -1,0 +1,24 @@
+{
+  "entry" : [
+    {
+      "id" : "blah",
+      "time" : 0,
+      "messaging" : [
+        {
+          "sender" : {
+            "id" : "subscription_test"
+          },
+          "recipient" : {
+            "id" : "3"
+          },
+          "timestamp" : 0,
+          "message" : {
+            "mid" : "",
+            "seq" : 0,
+            "text" : "football"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/facebookRequests/noCustomBriefingTopic.json
+++ b/src/test/resources/facebookRequests/noCustomBriefingTopic.json
@@ -1,0 +1,24 @@
+{
+  "entry" : [
+    {
+      "id" : "blah",
+      "time" : 0,
+      "messaging" : [
+        {
+          "sender" : {
+            "id" : "subscription_test"
+          },
+          "recipient" : {
+            "id" : "1"
+          },
+          "timestamp" : 0,
+          "message" : {
+            "mid" : "",
+            "seq" : 0,
+            "text" : "no"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/facebookResponses/customBriefingTopic.json
+++ b/src/test/resources/facebookResponses/customBriefingTopic.json
@@ -3,7 +3,7 @@
     "id" : "subscription_test"
   },
   "message" : {
-    "text" : "I can personalise your briefing. Do you want to choose a favourite topic?",
+    "text" : "Ok. Do you have another favourite topic?",
     "attachment" : null,
     "quick_replies" : [
       {

--- a/src/test/resources/facebookResponses/manageMorningBriefing.json
+++ b/src/test/resources/facebookResponses/manageMorningBriefing.json
@@ -19,6 +19,16 @@
         "content_type":"text",
         "title":"Unsubscribe",
         "payload":"unsubscribe"
+      },
+      {
+        "content_type":"text",
+        "title":"Remove topic",
+        "payload":"remove"
+      },
+      {
+        "content_type":"text",
+        "title":"Add topic",
+        "payload":"add"
       }
     ]
   }

--- a/src/test/resources/facebookResponses/noCustomBriefingTopic.json
+++ b/src/test/resources/facebookResponses/noCustomBriefingTopic.json
@@ -1,0 +1,41 @@
+{
+  "recipient":{
+    "id":"subscription_test"
+  },
+  "message":{
+    "text":"Done. You will start receiving the morning briefing at 06:00.\n\nRemember, you can change your subscription to this at any time from the menu.\n\nWould you like to see the headlines or the most popular stories right now?",
+    "quick_replies":[
+      {
+        "content_type":"text",
+        "title":"Headlines",
+        "payload":"headlines"
+      },
+      {
+        "content_type":"text",
+        "title":"Most popular",
+        "payload":"popular"
+      },
+      {
+        "content_type":"text",
+        "title":"Manage subscriptions",
+        "payload":"subscription"
+      },
+      {
+        "content_type":"text",
+        "title":"Suggest something",
+        "payload":"suggest"
+      },
+      {
+        "content_type":"text",
+        "title":"Give us feedback",
+        "payload":"feedback"
+      },
+      {
+        "content_type" : "text",
+        "title" : "Support the Guardian",
+        "payload" : "support",
+        "image_url" : null
+      }
+    ]
+  }
+}

--- a/src/test/scala/com/gu/facebook_news_bot/SubscriptionTest.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/SubscriptionTest.scala
@@ -48,10 +48,24 @@ class SubscriptionTest extends FunSpec with Matchers with ScalatestRouteTest wit
     )
   }
 
-  it("should respond to time of 6") {
+  it("should respond to briefing time by asking if user wants a customised briefing") {
     routeTest(
       "src/test/resources/facebookRequests/briefingTime.json",
       "src/test/resources/facebookResponses/briefingTime.json"
+    )
+  }
+
+  it("should respond to 1st topic choice by asking if user wants another topic") {
+    routeTest(
+      "src/test/resources/facebookRequests/customBriefingTopic.json",
+      "src/test/resources/facebookResponses/customBriefingTopic.json"
+    )
+  }
+
+  it("should respond to no with confirmation of subscription") {
+    routeTest(
+      "src/test/resources/facebookRequests/noCustomBriefingTopic.json",
+      "src/test/resources/facebookResponses/noCustomBriefingTopic.json"
     )
   }
 


### PR DESCRIPTION
- During sign-up, users are asked if they'd like to customise their briefing with up to 2 topics.
- From the manage subscription menu, users can add/remove topics.

TODO - send out a one-off message to all existing subscribers to see if they'd like to customise their briefings.

### Sign up:
![picture 3](https://cloud.githubusercontent.com/assets/1513454/22646285/79bfe044-ec63-11e6-9e6e-fda08a28ba1d.png)

### Managing topics:
![picture 4](https://cloud.githubusercontent.com/assets/1513454/22646291/8a6238fc-ec63-11e6-864c-3ceac0aaffd9.png)

