### PR TITLE
Send readers' editor url for long messages

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/FeedbackState.scala
@@ -35,5 +35,5 @@ trait FeedbackState extends State {
 object FeedbackState extends FeedbackState {
   val Name = "FEEDBACK"
 
-  val message = "How can we improve this service? Type here, and I'll pass it onto the Guardian."
+  val message = "How can we improve this service? Type here, and I'll pass it onto the Messenger developers."
 }


### PR DESCRIPTION
We get quite a lot of editorial-related comments via the feedback mechanism in the bot.
This change makes it a bit clearer that it's looking for feedback on the bot, and sends a link to Readers' Editor contact details for general messages that are over 200 chars.

![picture 5](https://cloud.githubusercontent.com/assets/1513454/22647888/bc953cfe-ec6b-11e6-964f-d384050e18e4.png)
