### PR TITLE
Use NLP to build capi queries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,6 +18,7 @@ val CapiVersion = "10.5"
 val AwsVersion = "1.11.8"
 
 libraryDependencies ++= Seq(
+  "org.clulab" %% "processors-corenlp" % "6.0.2",
   "com.google.guava" % "guava" % "19.0",
   "joda-time" % "joda-time" % "2.9.4",
   "org.joda" % "joda-convert" % "1.8.1",

--- a/cloudformation/cloudformation.yml
+++ b/cloudformation/cloudformation.yml
@@ -72,7 +72,7 @@ Mappings:
             MinSize: 1
             MaxSize: 2
             DesiredCapacity: 1
-            InstanceType: t2.micro
+            InstanceType: t2.small
 
 Resources:
     FacebookNewsBotRole:

--- a/facebook-news-bot.service
+++ b/facebook-news-bot.service
@@ -9,7 +9,7 @@ Restart=no
 EnvironmentFile=/etc/gu/conf
 Environment=STAGE=$STAGE
 Environment='HOME=/home/content-api'
-Environment='JAVA_OPTS=-Xms256m -Xmx256m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:ReservedCodeCacheSize=256m'
+Environment='JAVA_OPTS=-Xms256m -Xmx1024m -XX:+UseConcMarkSweepGC -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/home/content-api/logs/gc.log -XX:ReservedCodeCacheSize=1024m'
 WorkingDirectory=/home/content-api
 ExecStart=/home/content-api/bin/facebook-news-bot
 

--- a/src/main/scala/com/gu/facebook_news_bot/BotService.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/BotService.scala
@@ -14,13 +14,12 @@ import com.gu.cm.Mode
 import com.gu.facebook_news_bot.briefing.MorningBriefingPoller
 import com.gu.facebook_news_bot.football_transfers.{FootballTransferRumoursPoller, FootballTransfersPoller, FootballTransfersFeedbackPoller}
 import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
-import com.gu.facebook_news_bot.services.{Capi, CapiImpl, Facebook, FacebookImpl}
+import com.gu.facebook_news_bot.services._
 import de.heikoseeberger.akkahttpcirce.CirceSupport
 import io.circe.generic.auto._
 import com.gu.facebook_news_bot.state.StateHandler
 import com.gu.facebook_news_bot.stores.UserStore
-import com.gu.facebook_news_bot.utils.{JsonHelpers, Verification}
-import com.gu.facebook_news_bot.utils.{KinesisAppenderConfig, LogStash}
+import com.gu.facebook_news_bot.utils._
 import com.gu.facebook_news_bot.utils.Loggers._
 
 import scala.concurrent.duration._
@@ -192,6 +191,8 @@ object Bot extends App with BotService {
   val footballFeedbackPoller = PartialFunction.condOpt(BotConfig.football.feedbackEnabled) {
     case true => system.actorOf(FootballTransfersFeedbackPoller.props(facebook, capi, userStore))
   }
+
+  Parser.warmUp
 
   val bindingFuture = Http().bindAndHandle(routes, "0.0.0.0", BotConfig.port)
 }

--- a/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
@@ -4,9 +4,11 @@ import java.util.concurrent.TimeUnit
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.gu.contentapi.client.GuardianContentClient
-import com.gu.contentapi.client.model.ItemQuery
-import com.gu.contentapi.client.model.v1.{Content, ItemResponse}
+import com.gu.contentapi.client.model._
+import com.gu.contentapi.client.model.v1.{Content, ItemResponse, SearchResponse}
 import com.gu.facebook_news_bot.BotConfig
+import com.gu.facebook_news_bot.utils.Loggers.appLogger
+import com.gu.facebook_news_bot.utils.Parser
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -25,10 +27,23 @@ object CapiImpl extends Capi {
   private lazy val client = new GuardianContentClient(BotConfig.capi.key)
 
   def getHeadlines(edition: String, topic: Option[Topic]): Future[Seq[Content]] =
-    doQuery(basicItemQuery(topic.map(_.getPath(edition)).getOrElse(edition)).showEditorsPicks(), _.editorsPicks)
+    doQuery(edition, topic, _.showEditorsPicks(), _.editorsPicks)
 
   def getMostViewed(edition: String, topic: Option[Topic]): Future[Seq[Content]] =
-    doQuery(basicItemQuery(topic.map(_.getPath(edition)).getOrElse(edition)).showMostViewed(), _.mostViewed)
+    doQuery(edition, topic, _.showMostViewed(), _.mostViewed)
+
+  def doQuery(edition: String, topic: Option[Topic], itemQueryModifier: ItemQuery => ItemQuery, getResults: (ItemResponse => Option[Seq[Content]])): Future[Seq[Content]] = {
+    val query: ContentApiQuery = topic.map(_.getQuery(edition)).getOrElse(ItemQuery(edition))
+    query match {
+      case itemQuery @ ItemQuery(_,_) =>
+        val ops = itemQueryModifier andThen commonItemQueryParams
+        doItemQuery(ops(itemQuery), getResults)
+      case searchQuery @ SearchQuery(_) => doSearchQuery(commonSearchQueryParams(searchQuery))
+      case other =>
+        appLogger.error(s"Unexpected ContentApiQuery type: $other")
+        Future.successful(Nil)
+    }
+  }
 
   def getArticle(id: String): Future[Option[Content]] = {
     val query = ItemQuery(id).showFields("standfirst").showElements("image")
@@ -37,7 +52,7 @@ object CapiImpl extends Capi {
     }
   }
 
-  private def doQuery(query: ItemQuery, getResults: (ItemResponse => Option[Seq[Content]])): Future[Seq[Content]] = {
+  private def doItemQuery(query: ItemQuery, getResults: (ItemResponse => Option[Seq[Content]])): Future[Seq[Content]] = {
     CapiCache.get(query.toString).map(cached => Future.successful(cached)).getOrElse {
       client.getResponse(query) map { response: ItemResponse =>
 
@@ -51,11 +66,37 @@ object CapiImpl extends Capi {
     }
   }
 
-  private def basicItemQuery(item: String) = ItemQuery(item)
-    .showFields("standfirst")
+  private def doSearchQuery(query: SearchQuery): Future[Seq[Content]] = {
+    CapiCache.get(query.toString).map(cached => Future.successful(cached)).getOrElse {
+      client.getResponse(query) map { response: SearchResponse =>
+        val results = response.results
+        //These are the most relevant results according to CAPI, now sort by date
+        val sorted = results.sortWith { (a, b) =>
+          val result = for {
+            dateA <- a.webPublicationDate
+            dateB <- b.webPublicationDate
+          } yield dateA.dateTime > dateB.dateTime
+          result.getOrElse(false)
+        }
+
+        CapiCache.put(query.toString, sorted)
+        sorted
+      }
+    }
+  }
+
+  private def commonItemQueryParams: ItemQuery => ItemQuery =
+    _.showFields("standfirst")
     .tag("type/article")
     .showElements("image")
     .pageSize(25)   //Matches the number of editors-picks/most-viewed, in case they aren't available
+
+  private def commonSearchQueryParams: SearchQuery => SearchQuery =
+    _.showFields("standfirst")
+    .tag("type/article")
+    .showElements("image")
+    .pageSize(25)
+
 }
 
 object CapiCache {
@@ -70,7 +111,8 @@ object CapiCache {
 
 object Topic {
   def getTopic(text: String): Option[Topic] = {
-    TopicList.find(topic => topic.pattern.findFirstIn(text).isDefined)
+    val topic = TopicList.find(topic => topic.pattern.findFirstIn(text.toLowerCase).isDefined)
+    topic.orElse(SearchTopic(text)) //Uppercase chars can help with finding proper nouns
   }
 
   private val TopicList: List[Topic] = List(
@@ -118,29 +160,29 @@ object Topic {
 sealed trait Topic {
   val terms: List[String]
   lazy val pattern: Regex = ("""(^|\W)(""" + terms.mkString("|") + """)($|\W)""").r.unanchored
-  def getPath(edition: String): String
+  def getQuery(edition: String): ContentApiQuery
   def name: String = terms.headOption.getOrElse("")
 }
 
 case class SectionTopic(terms: List[String], section: String) extends Topic {
-  def getPath(edition: String) = section
+  def getQuery(edition: String) = ItemQuery(section)
 }
 object SectionTopic {
   def apply(section: String): SectionTopic = SectionTopic(List(section), section)
 }
 
 case class EditionSectionTopic(terms: List[String], section: String) extends Topic {
-  def getPath(edition: String) = {
+  def getQuery(edition: String) = ItemQuery({
     if (List("us","au").contains(edition.toLowerCase)) s"$edition/$section"
     else s"uk/$section"   //uk edition by default
-  }
+  })
 }
 object EditionSectionTopic {
   def apply(section: String): EditionSectionTopic = EditionSectionTopic(List(section), section)
 }
 
 case class SectionTagTopic(terms: List[String], section: String, tag: String) extends Topic {
-  def getPath(edition: String) = s"$section/$tag"
+  def getQuery(edition: String) = ItemQuery(s"$section/$tag")
 }
 object SectionTagTopic {
   def apply(section: String, tag: String): SectionTagTopic = SectionTagTopic(List(tag), section, tag)
@@ -149,11 +191,28 @@ object SectionTagTopic {
 case object PoliticsTopic extends Topic {
   val terms = List("politics")
 
-  def getPath(edition: String): String = {
+  def getQuery(edition: String): ItemQuery = ItemQuery({
     edition.toLowerCase match {
       case "us" => "us-news/us-politics"
       case "au" => "australia-news/australian-politics"
       case _ => "politics"
     }
+  })
+}
+
+//Special topic for searching CAPI for a set of terms, for when we can't match any topics
+case class SearchTopic(terms: List[String]) extends Topic {
+  def getQuery(edition: String) = {
+    val quoted = terms.map(term => if (term.contains(" ")) "\"" + term + "\"" else term)
+    SearchQuery().q(quoted.mkString(" AND "))
+  }
+
+  override def name: String = terms.mkString(", ")
+}
+object SearchTopic {
+  def apply(text: String): Option[SearchTopic] = {
+    val filtered = text.replaceAll("([hH]+eadlines|[nN]+ews|[sS]+tories|[pP]+opular)","")
+    val nouns = Parser.getNouns(filtered)
+    if (nouns.nonEmpty) Some(SearchTopic(nouns.distinct)) else None
   }
 }

--- a/src/main/scala/com/gu/facebook_news_bot/state/SearchFeedbackState.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/SearchFeedbackState.scala
@@ -1,0 +1,34 @@
+package com.gu.facebook_news_bot.state
+
+import com.gu.facebook_news_bot.models.{MessageFromFacebook, MessageToFacebook, User}
+import com.gu.facebook_news_bot.services.{Capi, Facebook}
+import com.gu.facebook_news_bot.state.StateHandler.Result
+import com.gu.facebook_news_bot.stores.UserStore
+import com.gu.facebook_news_bot.utils.Loggers.LogEvent
+import io.circe.generic.auto._
+
+import scala.concurrent.Future
+
+object SearchFeedbackState extends YesOrNoState {
+  val Name = "SEARCH_FEEDBACK_QUESTION"
+
+  private case class NoEvent(id: String, event: String = "search_feedback_no", _eventName: String = "search_feedback_no", topic: String) extends LogEvent
+  private case class YesEvent(id: String, event: String = "search_feedback_yes", _eventName: String = "search_feedback_yes", topic: String) extends LogEvent
+
+  protected def getQuestionText(user: User) = "Was this helpful?"
+
+  protected def yes(user: User, facebook: Facebook): Future[Result] = {
+    State.log(YesEvent(id = user.ID, topic = user.contentTopic.getOrElse("")))
+    val message = MessageToFacebook.textMessage(user.ID, "Great!")
+    Future.successful(State.changeState(user, MainState.Name), List(message))
+  }
+
+  protected def no(user: User): Future[Result] = {
+    State.log(NoEvent(id = user.ID, topic = user.contentTopic.getOrElse("")))
+    val message = MessageToFacebook.textMessage(user.ID, "Thanks for the feedback.")
+    Future.successful(State.changeState(user, MainState.Name), List(message))
+  }
+
+  protected override def unrecognised(user: User, messaging: MessageFromFacebook.Messaging, capi: Capi, facebook: Facebook, store: UserStore): Future[Result] =
+    MainState.transition(user, messaging, capi, facebook, store)
+}

--- a/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/state/StateHandler.scala
@@ -37,6 +37,7 @@ object StateHandler {
     OscarsNomsStates.UpdateTypeState,
     CustomBriefingQuestionState,
     RemoveCustomBriefingTopicState,
+    SearchFeedbackState,
     UnsubscribeState)
     .map((state: State) => (state.Name, state))
     .toMap + (StateHandler.NewUserStateName -> SubscribeQuestionState)

--- a/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/FacebookMessageBuilder.scala
@@ -10,7 +10,7 @@ object FacebookMessageBuilder {
   val MaxImageWidth = 1000
   val CarouselSize = 5  //Number of items in a carousel
 
-  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, currentTopic: Option[String], variant: Option[String] = None, includeMoreQuickReply: Boolean = true): Option[MessageToFacebook.Message] = {
+  def contentToCarousel(contentList: Seq[Content], offset: Int, edition: String, currentTopic: Option[String], variant: Option[String] = None, quickReplies: Boolean = true, includeMoreQuickReply: Boolean = true): Option[MessageToFacebook.Message] = {
     val sliced = contentList.slice(offset, offset + CarouselSize)
     if (sliced.isEmpty) None
     else {
@@ -25,27 +25,31 @@ object FacebookMessageBuilder {
       }
       val attachment = MessageToFacebook.Attachment.genericAttachment(tiles)
 
-      val moreQuickReply = {
-        if (includeMoreQuickReply) {
-          MessageToFacebook.QuickReply(
-            content_type = "text",
-            title = Some(currentTopic.map(topic => s"More $topic").getOrElse("More stories")),
-            payload = Some("more")
-          )
-        } else {
-          MessageToFacebook.QuickReply(
-            content_type = "text",
-            title = Some("Headlines"),
-            payload = Some("headlines")
-          )
-        }
-      }
-
       Some(MessageToFacebook.Message(
         attachment = Some(attachment),
-        quick_replies = Some(moreQuickReply :: topicQuickReplies(edition, currentTopic) ::: supportUsQuickReply :: Nil)
+        quick_replies = if (quickReplies) Some(getQuickReplies(includeMoreQuickReply, currentTopic, edition)) else None
       ))
     }
+  }
+
+  private def getQuickReplies(includeMoreQuickReply: Boolean, topic: Option[String], edition: String): Seq[MessageToFacebook.QuickReply] = {
+    val moreQuickReply = {
+      if (includeMoreQuickReply) {
+        MessageToFacebook.QuickReply(
+          content_type = "text",
+          title = Some(topic.map(topic => s"More $topic").getOrElse("More stories")),
+          payload = Some("more")
+        )
+      } else {
+        MessageToFacebook.QuickReply(
+          content_type = "text",
+          title = Some("Headlines"),
+          payload = Some("headlines")
+        )
+      }
+    }
+
+    moreQuickReply :: topicQuickReplies(edition, topic) ::: supportUsQuickReply :: Nil
   }
 
   def supportUsQuickReply = {

--- a/src/main/scala/com/gu/facebook_news_bot/utils/Parser.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/utils/Parser.scala
@@ -1,0 +1,56 @@
+package com.gu.facebook_news_bot.utils
+
+import org.clulab.processors.corenlp.CoreNLPProcessor
+import org.clulab.struct.Tree
+
+import scala.collection.immutable.Queue
+
+object Parser {
+  private val nlpProcessor = new CoreNLPProcessor()
+
+  def warmUp = nlpProcessor.annotate("warm") //Avoids delaying the response to the first request
+
+  def getNouns(text: String): List[String] = {
+    val doc = nlpProcessor.annotate(text)
+
+    doc.sentences.toList.flatMap { sentence =>
+      sentence.syntacticTree.map { tree =>
+        getTerms(tree)
+      }
+    }.flatten
+  }
+
+  /**
+    * @param consecutiveNouns  nouns which should be considered a single term, e.g. "Donald Duck"
+    * @param overall           the final set of terms in this tree
+    */
+  private case class Terms(consecutiveNouns: Queue[String], overall: Queue[String])
+
+  private def getTerms(tree: Tree): Queue[String] = {
+    tree.children.map { children: Array[Tree] =>
+      val result: Terms = children.foldLeft(Terms(Queue(),Queue())) { (terms, child) =>
+        if (child.value.matches("^NN[A-Z]*")) {
+          //The child of this node is a noun, add it to queue of consecutive nouns
+          child.children.flatMap(children => children.headOption.map(_.value)).map { noun: String =>
+            terms.copy(consecutiveNouns = terms.consecutiveNouns :+ noun)
+          } getOrElse terms
+
+        } else {
+          /**
+            * Not a noun:
+            * 1. Combine any consecutiveNouns into a single term
+            * 2. Recursively get any terms from this child tree
+            */
+          val currentTerm = if (terms.consecutiveNouns.isEmpty) None else Some(terms.consecutiveNouns.mkString(" "))
+          val childTerms = getTerms(child)
+          val toAppend = currentTerm.map(noun => childTerms :+ noun).getOrElse(childTerms)
+
+          terms.copy(overall = terms.overall ++ toAppend, consecutiveNouns = Queue())
+        }
+      }
+
+      val remainder = if (result.consecutiveNouns.isEmpty) None else Some(result.consecutiveNouns.mkString(" "))
+      remainder.map(result.overall :+ _).getOrElse(result.overall)
+    } getOrElse Queue()
+  }
+}

--- a/src/test/resources/capiResponses/headlines-search.json
+++ b/src/test/resources/capiResponses/headlines-search.json
@@ -1,0 +1,7618 @@
+[
+
+  {
+    "id": "us-news/2016/nov/12/suicide-prevention-hotline-record-calls-donald-trump-victory-lgbt",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T15:16:48Z",
+    "webTitle": "Suicide hotline calls reached record high as Trump victory became clear",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/suicide-prevention-hotline-record-calls-donald-trump-victory-lgbt",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/suicide-prevention-hotline-record-calls-donald-trump-victory-lgbt",
+    "fields": {
+      "standfirst": "<p>National Suicide Prevention Lifeline saw record 660 calls between 1am and 2am on Wednesday, amid particular concerns linked to LGBT community</p>"
+    },
+    "elements": [
+      {
+        "id": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/2000.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/1000.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/500.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/140.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/5184.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/5184.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/master/5184.jpg",
+            "typeData": {
+              "altText": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "caption": "People protest Donald Trump in Miami. As his coming victory became clear, the number of calls to a suicide prevention hotline surged.",
+              "credit": "Photograph: NR/ ddp USA / Barcroft Images",
+              "source": "NR/ ddp USA / Barcroft Images",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/master/5184.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          }
+        ]
+      },
+      {
+        "id": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/master/5184.jpg",
+            "typeData": {
+              "altText": "Trump Protests In Miami<br>MIAMI, FL - NOVEMBER 11: People chant and holds signs during a non-violent anti-Trump march and protest against President-elect Donald J. Trump, on November 11, 2016 in Miami, Florida. PHOTOGRAPH BY Nicole Raucheisen / ddp USA / Barcroft Images London-T:+44 207 033 1031 E:hello@barcroftmedia.com - New York-T:+1 212 796 2458 E:hello@barcroftusa.com - New Delhi-T:+91 11 4053 2429 E:hello@barcroftindia.com www.barcroftimages.com",
+              "credit": "Photograph: NR/ddp USA / Barcroft Images",
+              "photographer": "NR/ddp USA / Barcroft Images",
+              "source": "NR/ddp USA / Barcroft Images",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/master/5184.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/5184.jpg",
+            "typeData": {
+              "altText": "Trump Protests In Miami<br>MIAMI, FL - NOVEMBER 11: People chant and holds signs during a non-violent anti-Trump march and protest against President-elect Donald J. Trump, on November 11, 2016 in Miami, Florida. PHOTOGRAPH BY Nicole Raucheisen / ddp USA / Barcroft Images London-T:+44 207 033 1031 E:hello@barcroftmedia.com - New York-T:+1 212 796 2458 E:hello@barcroftusa.com - New Delhi-T:+91 11 4053 2429 E:hello@barcroftindia.com www.barcroftimages.com",
+              "credit": "Photograph: NR/ddp USA / Barcroft Images",
+              "photographer": "NR/ddp USA / Barcroft Images",
+              "source": "NR/ddp USA / Barcroft Images",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/5184.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/500.jpg",
+            "typeData": {
+              "altText": "Trump Protests In Miami<br>MIAMI, FL - NOVEMBER 11: People chant and holds signs during a non-violent anti-Trump march and protest against President-elect Donald J. Trump, on November 11, 2016 in Miami, Florida. PHOTOGRAPH BY Nicole Raucheisen / ddp USA / Barcroft Images London-T:+44 207 033 1031 E:hello@barcroftmedia.com - New York-T:+1 212 796 2458 E:hello@barcroftusa.com - New Delhi-T:+91 11 4053 2429 E:hello@barcroftindia.com www.barcroftimages.com",
+              "credit": "Photograph: NR/ddp USA / Barcroft Images",
+              "photographer": "NR/ddp USA / Barcroft Images",
+              "source": "NR/ddp USA / Barcroft Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "imageType": "Photograph",
+              "suppliersReference": "230275",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5",
+              "copyright": "Nicole Raucheisen / ddp USA / Barcroft Media"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/mood-hillary-clinton-election-party-changed-things-started-getting-crazy",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T15:01:00Z",
+    "webTitle": "‘It started getting scary’: how the mood changed at the Clinton election party",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/mood-hillary-clinton-election-party-changed-things-started-getting-crazy",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/mood-hillary-clinton-election-party-changed-things-started-getting-crazy",
+    "fields": {
+      "standfirst": "The gathering at New York’s Javits convention centre began in a celebratory mood. Three women who were there recall what happened next"
+    },
+    "elements": [
+      {
+        "id": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/2000.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/1000.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/500.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/140.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/6145.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "6145",
+              "height": "3687",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/6145.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/master/6145.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night",
+              "caption": "Hillary Clinton supporters at the The Jacob Javits convention centre, on election night.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "6145",
+              "height": "3687",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/master/6145.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          }
+        ]
+      },
+      {
+        "id": "df858421bbdf91356b8fa887394b201b919c922a",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/384.jpg",
+            "typeData": {
+              "altText": "Hedy Sloane Stempler.",
+              "caption": "Hedy Sloane Stempler.",
+              "credit": "Photograph: Kristen Lowenkron",
+              "source": "Kristen Lowenkron",
+              "width": "384",
+              "height": "384",
+              "secureFile": "https://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/384.jpg",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "df858421bbdf91356b8fa887394b201b919c922a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/df858421bbdf91356b8fa887394b201b919c922a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/master/384.jpg",
+            "typeData": {
+              "altText": "Hedy Sloane Stempler.",
+              "caption": "Hedy Sloane Stempler.",
+              "credit": "Photograph: Kristen Lowenkron",
+              "source": "Kristen Lowenkron",
+              "width": "384",
+              "height": "384",
+              "secureFile": "https://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/master/384.jpg",
+              "isMaster": "true",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "df858421bbdf91356b8fa887394b201b919c922a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/df858421bbdf91356b8fa887394b201b919c922a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/140.jpg",
+            "typeData": {
+              "altText": "Hedy Sloane Stempler.",
+              "caption": "Hedy Sloane Stempler.",
+              "credit": "Photograph: Kristen Lowenkron",
+              "source": "Kristen Lowenkron",
+              "width": "140",
+              "height": "140",
+              "secureFile": "https://media.guim.co.uk/df858421bbdf91356b8fa887394b201b919c922a/37_1_384_384/140.jpg",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "df858421bbdf91356b8fa887394b201b919c922a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/df858421bbdf91356b8fa887394b201b919c922a"
+            }
+          }
+        ]
+      },
+      {
+        "id": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/7043.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "7043",
+              "height": "4227",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/7043.jpg",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/master/7043.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "7043",
+              "height": "4227",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/master/7043.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/2000.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/1000.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/500.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/140.jpg",
+            "typeData": {
+              "altText": "Ellen Frances and Oona.",
+              "caption": "Ellen Frances and Oona.",
+              "credit": "Photograph: Ali Smith for the Observer",
+              "photographer": "Ali Smith",
+              "source": "The Observer",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/ef6e0eaa3bb9033778dddeac4932423eefd9df1d/0_0_7043_4227/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "ef6e0eaa3bb9033778dddeac4932423eefd9df1d",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/ef6e0eaa3bb9033778dddeac4932423eefd9df1d"
+            }
+          }
+        ]
+      },
+      {
+        "id": "e5ad801d571eec23d1e2cf578200cee63be44006",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/6205.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "6205",
+              "height": "3723",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/6205.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/master/6205.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "6205",
+              "height": "3723",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/master/6205.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/2000.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/1000.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/500.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/140.jpg",
+            "typeData": {
+              "altText": "Carmen Rita Wong and daughter Bianca Luz",
+              "caption": "Carmen Rita Wong and daughter Bianca Luz.",
+              "credit": "Photograph: Ali Smith for the Guardian",
+              "photographer": "Ali Smith",
+              "source": "The Guardian",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/e5ad801d571eec23d1e2cf578200cee63be44006/0_112_6205_3723/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5ad801d571eec23d1e2cf578200cee63be44006",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5ad801d571eec23d1e2cf578200cee63be44006"
+            }
+          }
+        ]
+      },
+      {
+        "id": "0667a6c971419311b31bd04f54e77ee73dde7075",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/151.jpg",
+            "typeData": {
+              "caption": "Meha",
+              "credit": "Photograph: LinkedIn",
+              "source": "LinkedIn",
+              "width": "151",
+              "height": "151",
+              "secureFile": "https://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/151.jpg",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "0667a6c971419311b31bd04f54e77ee73dde7075",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/0667a6c971419311b31bd04f54e77ee73dde7075"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/master/151.jpg",
+            "typeData": {
+              "caption": "Meha",
+              "credit": "Photograph: LinkedIn",
+              "source": "LinkedIn",
+              "width": "151",
+              "height": "151",
+              "secureFile": "https://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/master/151.jpg",
+              "isMaster": "true",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "0667a6c971419311b31bd04f54e77ee73dde7075",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/0667a6c971419311b31bd04f54e77ee73dde7075"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/140.jpg",
+            "typeData": {
+              "caption": "Meha",
+              "credit": "Photograph: LinkedIn",
+              "source": "LinkedIn",
+              "width": "140",
+              "height": "140",
+              "secureFile": "https://media.guim.co.uk/0667a6c971419311b31bd04f54e77ee73dde7075/24_15_151_151/140.jpg",
+              "displayCredit": "false",
+              "role": "thumbnail",
+              "mediaId": "0667a6c971419311b31bd04f54e77ee73dde7075",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/0667a6c971419311b31bd04f54e77ee73dde7075"
+            }
+          }
+        ]
+      },
+      {
+        "id": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/master/6145.jpg",
+            "typeData": {
+              "altText": "Hilary supporters respond as election results come in at the Hilary Clinton Election Night Speech and Party at The Jacob Javits Convention Center, NYC.11/8/16\rPhotograph by Ali Smith",
+              "credit": "Photograph: Ali Smith for the Guardian/Photograph by Ali Smith",
+              "photographer": "Ali Smith for the Guardian",
+              "source": "Photograph by Ali Smith",
+              "width": "6145",
+              "height": "3687",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/master/6145.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/6145.jpg",
+            "typeData": {
+              "altText": "Hilary supporters respond as election results come in at the Hilary Clinton Election Night Speech and Party at The Jacob Javits Convention Center, NYC.11/8/16\rPhotograph by Ali Smith",
+              "credit": "Photograph: Ali Smith for the Guardian/Photograph by Ali Smith",
+              "photographer": "Ali Smith for the Guardian",
+              "source": "Photograph by Ali Smith",
+              "width": "6145",
+              "height": "3687",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/6145.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/500.jpg",
+            "typeData": {
+              "altText": "Hilary supporters respond as election results come in at the Hilary Clinton Election Night Speech and Party at The Jacob Javits Convention Center, NYC.11/8/16\rPhotograph by Ali Smith",
+              "credit": "Photograph: Ali Smith for the Guardian/Photograph by Ali Smith",
+              "photographer": "Ali Smith for the Guardian",
+              "source": "Photograph by Ali Smith",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "imageType": "Photograph",
+              "suppliersReference": "alismithphoto@mac.com",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e0cdc1775108ef4cb06f1ad05806524ee1760a58",
+              "copyright": "Ali Smith/ The Guardian"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "lifeandstyle/2016/nov/12/legal-marijuana-weed-high-times-2016-election",
+    "type": "article",
+    "sectionId": "lifeandstyle",
+    "sectionName": "Life and style",
+    "webPublicationDate": "2016-11-12T15:00:52Z",
+    "webTitle": "Nervous about a Trump presidency? Me too. But at least I've got legal weed",
+    "webUrl": "https://www.theguardian.com/lifeandstyle/2016/nov/12/legal-marijuana-weed-high-times-2016-election",
+    "apiUrl": "https://content.guardianapis.com/lifeandstyle/2016/nov/12/legal-marijuana-weed-high-times-2016-election",
+    "fields": {
+      "standfirst": "<p>Writer and cannabis consultant David Bienenstock reflects on a night of progressive marijuana legislation – in the face of regressive everything else</p>"
+    },
+    "elements": [
+      {
+        "id": "5df8c63768f12807b338c433187a136acd213698",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/2000.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/1000.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/500.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/140.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/5200.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "5200",
+              "height": "3120",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/5200.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/master/5200.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "caption": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization. ",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "5200",
+              "height": "3120",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/master/5200.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      },
+      {
+        "id": "5df8c63768f12807b338c433187a136acd213698",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/master/5200.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization.",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "5200",
+              "height": "3120",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/master/5200.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/5200.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization.",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "5200",
+              "height": "3120",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/5200.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/500.jpg",
+            "typeData": {
+              "altText": "Farmworkers inside a drying barn take down newly-harvested marijuana plants after a drying period at Los Suenos Farms in Avondale, Colorado. On Tuesday, states with pro-marijuana ballot measures voted overwhelmingly in favor of legalization.",
+              "credit": "Photograph: Brennan Linsley/AP",
+              "photographer": "Brennan Linsley",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "5df8c63768f12807b338c433187a136acd213698",
+              "imageType": "Photograph",
+              "suppliersReference": "COBL504",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5df8c63768f12807b338c433187a136acd213698",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "football/2016/nov/12/usa-mexico-soccer-fans-donald-trump",
+    "type": "article",
+    "sectionId": "football",
+    "sectionName": "Football",
+    "webPublicationDate": "2016-11-12T14:47:20Z",
+    "webTitle": "USA and Mexico soccer fans get on just fine, despite the awkward politics",
+    "webUrl": "https://www.theguardian.com/football/2016/nov/12/usa-mexico-soccer-fans-donald-trump",
+    "apiUrl": "https://content.guardianapis.com/football/2016/nov/12/usa-mexico-soccer-fans-donald-trump",
+    "fields": {
+      "standfirst": "<p>Donald Trump’s election victory raised the prospect of added tension at Friday’s World Cup qualifier, but the game in Columbus went off without a hitch</p>"
+    },
+    "elements": [
+      {
+        "id": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/2000.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/1000.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/500.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/140.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/4446.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "4446",
+              "height": "2668",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/4446.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/master/4446.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "caption": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "4446",
+              "height": "2668",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/master/4446.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          }
+        ]
+      },
+      {
+        "id": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/master/4446.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "4446",
+              "height": "2668",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/master/4446.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/4446.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "4446",
+              "height": "2668",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/4446.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/500.jpg",
+            "typeData": {
+              "altText": "Fans cheer for their team before the game in Columbus.",
+              "credit": "Photograph: Jay LaPrete/AP",
+              "photographer": "Jay LaPrete",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "73eeba8441f00a4eb11fd2b3ae41817806fa8725",
+              "imageType": "Photograph",
+              "suppliersReference": "OHJL102",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/73eeba8441f00a4eb11fd2b3ae41817806fa8725"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/donald-trump-appears-to-soften-stance-on-range-of-pledges",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T14:45:16Z",
+    "webTitle": "Donald Trump appears to soften on Clinton emails and Obamacare",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/donald-trump-appears-to-soften-stance-on-range-of-pledges",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/donald-trump-appears-to-soften-stance-on-range-of-pledges",
+    "fields": {
+      "standfirst": "<p>In first interview since winning election, Trump says he may not repeal Obamacare and Clinton’s prosecution not a priority</p>"
+    },
+    "elements": [
+      {
+        "id": "b250b829104b4f94af3a02129cf20a5c81654f96",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/2000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/1000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/500.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/140.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/5000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "5000",
+              "height": "3000",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/5000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/master/5000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "caption": "Donald Trump made his comments in an inteview with the Wall Street Journal.",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "5000",
+              "height": "3000",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/master/5000.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          }
+        ]
+      },
+      {
+        "id": "b250b829104b4f94af3a02129cf20a5c81654f96",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/master/5000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "5000",
+              "height": "3000",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/master/5000.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/5000.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "5000",
+              "height": "3000",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/5000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/500.jpg",
+            "typeData": {
+              "altText": "Donald Trump",
+              "credit": "Photograph: Jim Watson/AFP/Getty Images",
+              "photographer": "Jim Watson",
+              "source": "AFP/Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b250b829104b4f94af3a02129cf20a5c81654f96",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I05ZY",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b250b829104b4f94af3a02129cf20a5c81654f96",
+              "copyright": "AFP or licensors"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "world/2016/nov/12/former-us-ambassador-moscow-russia-banned",
+    "type": "article",
+    "sectionId": "world",
+    "sectionName": "World news",
+    "webPublicationDate": "2016-11-12T14:29:44Z",
+    "webTitle": "Former US ambassador to Moscow banned from entering Russia",
+    "webUrl": "https://www.theguardian.com/world/2016/nov/12/former-us-ambassador-moscow-russia-banned",
+    "apiUrl": "https://content.guardianapis.com/world/2016/nov/12/former-us-ambassador-moscow-russia-banned",
+    "fields": {
+      "standfirst": "<ul><li>Michael McFaul applied for visa to help Hillary Clinton prepare for office</li><li>Russian source says ambassador was banned in 2014</li></ul>"
+    },
+    "elements": [
+      {
+        "id": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/2000.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/1000.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/500.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/140.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/5184.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/5184.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/master/5184.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "caption": "Michael McFaul was ambassador to Russia between 2012 and 2014.",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/master/5184.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      },
+      {
+        "id": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/master/5184.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/master/5184.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/5184.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "5184",
+              "height": "3110",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/5184.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/500.jpg",
+            "typeData": {
+              "altText": "Michael McFaul",
+              "credit": "Photograph: David Goldman/AP",
+              "photographer": "David Goldman",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/043557c45ecec9746ea8a2c33da04c4906d08f0a/0_0_5184_3110/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "imageType": "Photograph",
+              "suppliersReference": "WX104",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/043557c45ecec9746ea8a2c33da04c4906d08f0a",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "football/2016/nov/12/usa-mexico-marquez-five-things-we-learned",
+    "type": "article",
+    "sectionId": "football",
+    "sectionName": "Football",
+    "webPublicationDate": "2016-11-12T14:10:56Z",
+    "webTitle": "USA 1-2 Mexico: five things we learned from World Cup qualifying",
+    "webUrl": "https://www.theguardian.com/football/2016/nov/12/usa-mexico-marquez-five-things-we-learned",
+    "apiUrl": "https://content.guardianapis.com/football/2016/nov/12/usa-mexico-marquez-five-things-we-learned",
+    "fields": {
+      "standfirst": "<p>Forget the 7-0 thrashing by Chile in the summer – Mexico are a seriously good team; and Jürgen Klinsmann lost the tactical battle to Juan Carlos Osorio</p>"
+    },
+    "elements": [
+      {
+        "id": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2000.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/1000.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/500.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/140.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2210.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2210",
+              "height": "1326",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2210.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/master/2210.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "caption": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2210",
+              "height": "1326",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/master/2210.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          }
+        ]
+      },
+      {
+        "id": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/3192.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "3192",
+              "height": "2305",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/3192.jpg",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/master/3192.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "3192",
+              "height": "2305",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/master/3192.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/2000.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2000",
+              "height": "1444",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/1000.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "1000",
+              "height": "722",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/500.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "500",
+              "height": "361",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/140.jpg",
+            "typeData": {
+              "altText": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "caption": "Carlos Salcido goes in hard on Christian Pulisic.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "140",
+              "height": "101",
+              "secureFile": "https://media.guim.co.uk/49b3d75bf6b57ba9ca23db20681415a7e624270b/0_0_3192_2305/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/49b3d75bf6b57ba9ca23db20681415a7e624270b",
+              "copyright": "USA Today Sports"
+            }
+          }
+        ]
+      },
+      {
+        "id": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/master/2210.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2210",
+              "height": "1326",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/master/2210.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2210.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "2210",
+              "height": "1326",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/2210.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/500.jpg",
+            "typeData": {
+              "altText": "Rafael Marquez celebrates Mexico’s victory over USA in Columbus.",
+              "credit": "Photograph: Trevor Ruszkowski/USA Today Sports",
+              "photographer": "Trevor Ruszkowski",
+              "source": "USA Today Sports",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/54a9678fae582f74a913590b9a7bcf5a073575b0/0_50_2210_1326/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/54a9678fae582f74a913590b9a7bcf5a073575b0",
+              "copyright": "USA Today Sports"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "politics/2016/nov/12/nigel-farage-arrives-in-new-york-to-meet-president-elect",
+    "type": "article",
+    "sectionId": "politics",
+    "sectionName": "Politics",
+    "webPublicationDate": "2016-11-12T14:00:17Z",
+    "webTitle": "Nigel Farage arrives in New York ahead of possible Trump meeting",
+    "webUrl": "https://www.theguardian.com/politics/2016/nov/12/nigel-farage-arrives-in-new-york-to-meet-president-elect",
+    "apiUrl": "https://content.guardianapis.com/politics/2016/nov/12/nigel-farage-arrives-in-new-york-to-meet-president-elect",
+    "fields": {
+      "standfirst": "<p>Interim Ukip leader fuels speculation he will be first UK politician to congratulate Trump in person since US election win</p>"
+    },
+    "elements": [
+      {
+        "id": "6737dd98d7be180e23930a493513e487274a13f9",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/140.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "caption": "Farage, who met Trump during his campaign rallies, is thought to have arrived in the city on Saturday.",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/500.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "caption": "Farage, who met Trump during his campaign rallies, is thought to have arrived in the city on Saturday.",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1000.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "caption": "Farage, who met Trump during his campaign rallies, is thought to have arrived in the city on Saturday.",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1901.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "caption": "Farage, who met Trump during his campaign rallies, is thought to have arrived in the city on Saturday.",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "1901",
+              "height": "1141",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1901.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/master/1901.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "caption": "Farage, who met Trump during his campaign rallies, is thought to have arrived in the city on Saturday.",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "1901",
+              "height": "1141",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/master/1901.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6737dd98d7be180e23930a493513e487274a13f9",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/master/1901.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "1901",
+              "height": "1141",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/master/1901.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1901.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "1901",
+              "height": "1141",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/1901.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/500.jpg",
+            "typeData": {
+              "altText": "Nigel Farage and Donald Trump",
+              "credit": "Photograph: Gerald Herbert/AP",
+              "photographer": "Gerald Herbert",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6737dd98d7be180e23930a493513e487274a13f9/342_0_1901_1141/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6737dd98d7be180e23930a493513e487274a13f9",
+              "imageType": "Photograph",
+              "suppliersReference": "LON114",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6737dd98d7be180e23930a493513e487274a13f9",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved. This material may not be published, broadcast, rewritten or redistribu"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/flint-michigan-lead-bottled-water-delivery",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T13:50:59Z",
+    "webTitle": "Bottled water must be delivered to Flint residents in lead crisis, judge rules",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/flint-michigan-lead-bottled-water-delivery",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/flint-michigan-lead-bottled-water-delivery",
+    "fields": {
+      "standfirst": "<p>‘Surprise’ decision hailed as governor’s spokesman says state attorneys are reviewing order, with officials saying door-to-door delivery would cost $9m</p>"
+    },
+    "elements": [
+      {
+        "id": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/2000.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/1000.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/500.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/140.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/4644.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "4644",
+              "height": "2786",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/4644.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/master/4644.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "caption": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "4644",
+              "height": "2786",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/master/4644.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          }
+        ]
+      },
+      {
+        "id": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/master/4644.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "4644",
+              "height": "2786",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/master/4644.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/4644.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "4644",
+              "height": "2786",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/4644.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/500.jpg",
+            "typeData": {
+              "altText": "Flint resident Lisia Williams shouts as Governor Rick Snyder answers questions from US representatives during a hearing about the Flint water crisis in March.",
+              "credit": "Photograph: Jake May/AP",
+              "photographer": "Jake May",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/e5882a7e265293e00395704a8e7ee0bfcab2c132/0_216_4644_2786/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "e5882a7e265293e00395704a8e7ee0bfcab2c132",
+              "imageType": "Photograph",
+              "suppliersReference": "MIFLI105",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/e5882a7e265293e00395704a8e7ee0bfcab2c132"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/11/anti-trump-protests-weekend-new-york-trump-tower",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T13:40:57Z",
+    "webTitle": "Anti-Trump protesters gear up for weekend demonstrations across the US",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/11/anti-trump-protests-weekend-new-york-trump-tower",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/11/anti-trump-protests-weekend-new-york-trump-tower",
+    "fields": {
+      "standfirst": "<ul><li>One man shot and wounded during rowdy protests in Portland, Oregon</li><li>More than 10,000 sign up for Saturday march in New York<br></li></ul>"
+    },
+    "elements": [
+      {
+        "id": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/140.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/500.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/1000.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/2000.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/5368.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "5368",
+              "height": "3220",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/5368.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/master/5368.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "caption": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president. ",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "5368",
+              "height": "3220",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/master/5368.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          }
+        ]
+      },
+      {
+        "id": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/3500.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2100",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/3500.jpg",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/master/3500.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2100",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/master/3500.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/2000.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/1000.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/500.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/140.jpg",
+            "typeData": {
+              "altText": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "caption": "Protesters in Portland, Oregon, on the night of Thursday 10 November.",
+              "credit": "Photograph: STRINGER/Reuters",
+              "photographer": "STRINGER",
+              "source": "Reuters",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/024131172cdf020dee8eb6c2ff8530d7b7555693/0_235_3500_2100/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "024131172cdf020dee8eb6c2ff8530d7b7555693",
+              "imageType": "Photograph",
+              "suppliersReference": "PSP22",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/024131172cdf020dee8eb6c2ff8530d7b7555693"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/master/5368.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president.",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "5368",
+              "height": "3220",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/master/5368.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/5368.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president.",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "5368",
+              "height": "3220",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/5368.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/500.jpg",
+            "typeData": {
+              "altText": "Thousands have taken to the streets across the country in the days since Donald Trump was elected president.",
+              "credit": "Photograph: Stephen Lovekin/REX/Shutterstock",
+              "photographer": "Stephen Lovekin/REX/Shutterstock",
+              "source": "Stephen Lovekin/REX/Shutterstock",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6c2c9d63d89802ad737924ba9cfbde199769e7fb/0_37_5368_3220/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "imageType": "Photograph",
+              "suppliersReference": "7431021e",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6c2c9d63d89802ad737924ba9cfbde199769e7fb",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/seattle-mourns-trump-victory-close-knit-pain",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T13:32:11Z",
+    "webTitle": "‘We’re close-knit. It helps ease the pain’: Seattle mourns Trump’s victory",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/seattle-mourns-trump-victory-close-knit-pain",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/seattle-mourns-trump-victory-close-knit-pain",
+    "fields": {
+      "standfirst": "In the most liberal of cities on the ‘left coast’, residents tell of their sadness and anger at the election"
+    },
+    "elements": [
+      {
+        "id": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1000.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "caption": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/500.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "caption": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/140.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "caption": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1853.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "caption": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "1853",
+              "height": "1112",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1853.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/master/1853.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "caption": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in.",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "1853",
+              "height": "1112",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/master/1853.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          }
+        ]
+      },
+      {
+        "id": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/3338.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "3338",
+              "height": "2003",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/3338.jpg",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/master/3338.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "3338",
+              "height": "2003",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/master/3338.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/2000.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/1000.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/500.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/140.jpg",
+            "typeData": {
+              "altText": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "caption": "A Democrat supporter in Seattle’s Capitol Hill neighbourhood during an anti-Trump protest.",
+              "credit": "Photograph: Ted S. Warren/AP",
+              "photographer": "Ted S. Warren",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/f6ec1c69ef01a4c967952d06055cd00151673a51/0_109_3338_2003/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "imageType": "Photograph",
+              "suppliersReference": "WATW312",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f6ec1c69ef01a4c967952d06055cd00151673a51",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      },
+      {
+        "id": "45e16d05923f16a9dce028488d849ef638e4e711",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/3456.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "3456",
+              "height": "2074",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/3456.jpg",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/master/3456.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "3456",
+              "height": "2074",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/master/3456.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/2000.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/1000.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/500.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/140.jpg",
+            "typeData": {
+              "altText": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "caption": "Anti-Trump protesters march down Seattle’s Second Avenue.",
+              "credit": "Photograph: Karen Ducey/Getty Images",
+              "photographer": "Karen Ducey",
+              "source": "Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/45e16d05923f16a9dce028488d849ef638e4e711/0_198_3456_2074/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "45e16d05923f16a9dce028488d849ef638e4e711",
+              "imageType": "Photograph",
+              "suppliersReference": "622093462",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/45e16d05923f16a9dce028488d849ef638e4e711",
+              "copyright": "2016 Getty Images"
+            }
+          }
+        ]
+      },
+      {
+        "id": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/master/1853.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "1853",
+              "height": "1112",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/master/1853.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1853.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "1853",
+              "height": "1112",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/1853.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/500.jpg",
+            "typeData": {
+              "altText": "Seattle resident and Democrat supporter Sri Vasamsetti anxiously watches the results come in",
+              "credit": "Photograph: Sy Bean/AP",
+              "photographer": "Sy Bean",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2/0_94_1853_1112/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "8b3b761aada81a41e5709ff5a2fcd4c396fc80d2",
+              "imageType": "Photograph",
+              "suppliersReference": "WASET108",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8b3b761aada81a41e5709ff5a2fcd4c396fc80d2"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "books/2016/nov/12/xenophobic-populist-path-philippe-sands-conversation-with-hisham-matar",
+    "type": "article",
+    "sectionId": "books",
+    "sectionName": "Books",
+    "webPublicationDate": "2016-11-12T13:00:50Z",
+    "webTitle": "‘We’re on a xenophobic path – someone needs to press pause’: Philippe Sands in conversation with Hisham Matar",
+    "webUrl": "https://www.theguardian.com/books/2016/nov/12/xenophobic-populist-path-philippe-sands-conversation-with-hisham-matar",
+    "apiUrl": "https://content.guardianapis.com/books/2016/nov/12/xenophobic-populist-path-philippe-sands-conversation-with-hisham-matar",
+    "fields": {
+      "standfirst": "<p>The lawyer and novelist, both nominated for the Baillie Gifford prize for non-fiction, announced on 15 November, discuss human rights, citizenship and identity</p>"
+    },
+    "elements": [
+      {
+        "id": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/2000.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/1000.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/500.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/140.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/3367.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "3367",
+              "height": "2021",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/3367.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/master/3367.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "caption": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "3367",
+              "height": "2021",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/master/3367.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          }
+        ]
+      },
+      {
+        "id": "c331c737222a1854cda986368e2c608ecb96eb91",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/2010.jpg",
+            "typeData": {
+              "altText": "Philippe’s grandfather Leon’s house in Lviv",
+              "caption": "Philippe’s grandfather Leon’s house in Lviv",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "2010",
+              "height": "2311",
+              "secureFile": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/2010.jpg",
+              "displayCredit": "true",
+              "mediaId": "c331c737222a1854cda986368e2c608ecb96eb91",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/c331c737222a1854cda986368e2c608ecb96eb91"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/master/2010.jpg",
+            "typeData": {
+              "altText": "Philippe’s grandfather Leon’s house in Lviv",
+              "caption": "Philippe’s grandfather Leon’s house in Lviv",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "2010",
+              "height": "2311",
+              "secureFile": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/master/2010.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "c331c737222a1854cda986368e2c608ecb96eb91",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/c331c737222a1854cda986368e2c608ecb96eb91"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/1740.jpg",
+            "typeData": {
+              "altText": "Philippe’s grandfather Leon’s house in Lviv",
+              "caption": "Philippe’s grandfather Leon’s house in Lviv",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "1740",
+              "height": "2000",
+              "secureFile": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/1740.jpg",
+              "displayCredit": "true",
+              "mediaId": "c331c737222a1854cda986368e2c608ecb96eb91",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/c331c737222a1854cda986368e2c608ecb96eb91"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/870.jpg",
+            "typeData": {
+              "altText": "Philippe’s grandfather Leon’s house in Lviv",
+              "caption": "Philippe’s grandfather Leon’s house in Lviv",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "870",
+              "height": "1000",
+              "secureFile": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/870.jpg",
+              "displayCredit": "true",
+              "mediaId": "c331c737222a1854cda986368e2c608ecb96eb91",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/c331c737222a1854cda986368e2c608ecb96eb91"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/435.jpg",
+            "typeData": {
+              "altText": "Philippe’s grandfather Leon’s house in Lviv",
+              "caption": "Philippe’s grandfather Leon’s house in Lviv",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "435",
+              "height": "500",
+              "secureFile": "https://media.guim.co.uk/c331c737222a1854cda986368e2c608ecb96eb91/0_0_2010_2311/435.jpg",
+              "displayCredit": "true",
+              "mediaId": "c331c737222a1854cda986368e2c608ecb96eb91",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/c331c737222a1854cda986368e2c608ecb96eb91"
+            }
+          }
+        ]
+      },
+      {
+        "id": "003b725a07e5cf0dfbc493d25a2b1216adb4a3e6",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/600.jpg",
+            "typeData": {
+              "altText": "Libya",
+              "caption": "Libya",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "600",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/600.jpg",
+              "displayCredit": "true",
+              "mediaId": "003b725a07e5cf0dfbc493d25a2b1216adb4a3e6",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/master/600.jpg",
+            "typeData": {
+              "altText": "Libya",
+              "caption": "Libya",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "600",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/master/600.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "003b725a07e5cf0dfbc493d25a2b1216adb4a3e6",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/500.jpg",
+            "typeData": {
+              "altText": "Libya",
+              "caption": "Libya",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "500",
+              "height": "500",
+              "secureFile": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "003b725a07e5cf0dfbc493d25a2b1216adb4a3e6",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/140.jpg",
+            "typeData": {
+              "altText": "Libya",
+              "caption": "Libya",
+              "credit": "Photograph: Diana Matar",
+              "source": "Diana Matar",
+              "width": "140",
+              "height": "140",
+              "secureFile": "https://media.guim.co.uk/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6/0_0_600_600/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "003b725a07e5cf0dfbc493d25a2b1216adb4a3e6",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/003b725a07e5cf0dfbc493d25a2b1216adb4a3e6"
+            }
+          }
+        ]
+      },
+      {
+        "id": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/2010.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "2010",
+              "height": "2010",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/2010.jpg",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/master/2010.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "2010",
+              "height": "2010",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/master/2010.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/2000.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "2000",
+              "height": "2000",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/1000.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "1000",
+              "height": "1000",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/500.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "500",
+              "height": "500",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/140.jpg",
+            "typeData": {
+              "altText": "Philippe Sands",
+              "caption": "Philippe Sands",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "140",
+              "height": "140",
+              "secureFile": "https://media.guim.co.uk/4ca4363be09b3eb7a918468f2f6434d59b8c00b2/0_0_2010_2010/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "4ca4363be09b3eb7a918468f2f6434d59b8c00b2",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/4ca4363be09b3eb7a918468f2f6434d59b8c00b2"
+            }
+          }
+        ]
+      },
+      {
+        "id": "9bd2822a193b80ac8e269bc7c05dea3df86c92be",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/1105.jpg",
+            "typeData": {
+              "altText": "Hisham Matar, taken by his wife,",
+              "caption": "Hisham Matar, taken by his wife.",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "1105",
+              "height": "1107",
+              "secureFile": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/1105.jpg",
+              "displayCredit": "false",
+              "mediaId": "9bd2822a193b80ac8e269bc7c05dea3df86c92be",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9bd2822a193b80ac8e269bc7c05dea3df86c92be"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/master/1105.jpg",
+            "typeData": {
+              "altText": "Hisham Matar, taken by his wife,",
+              "caption": "Hisham Matar, taken by his wife.",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "1105",
+              "height": "1107",
+              "secureFile": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/master/1105.jpg",
+              "isMaster": "true",
+              "displayCredit": "false",
+              "mediaId": "9bd2822a193b80ac8e269bc7c05dea3df86c92be",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9bd2822a193b80ac8e269bc7c05dea3df86c92be"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/998.jpg",
+            "typeData": {
+              "altText": "Hisham Matar, taken by his wife,",
+              "caption": "Hisham Matar, taken by his wife.",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "998",
+              "height": "1000",
+              "secureFile": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/998.jpg",
+              "displayCredit": "false",
+              "mediaId": "9bd2822a193b80ac8e269bc7c05dea3df86c92be",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9bd2822a193b80ac8e269bc7c05dea3df86c92be"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/499.jpg",
+            "typeData": {
+              "altText": "Hisham Matar, taken by his wife,",
+              "caption": "Hisham Matar, taken by his wife.",
+              "credit": "Photograph: Diana Matar/PR",
+              "photographer": "Diana Matar",
+              "source": "PR",
+              "width": "499",
+              "height": "500",
+              "secureFile": "https://media.guim.co.uk/9bd2822a193b80ac8e269bc7c05dea3df86c92be/0_0_1105_1107/499.jpg",
+              "displayCredit": "false",
+              "mediaId": "9bd2822a193b80ac8e269bc7c05dea3df86c92be",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9bd2822a193b80ac8e269bc7c05dea3df86c92be"
+            }
+          }
+        ]
+      },
+      {
+        "id": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/master/3367.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "3367",
+              "height": "2021",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/master/3367.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/3367.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "3367",
+              "height": "2021",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/3367.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/500.jpg",
+            "typeData": {
+              "altText": "Philippe Sands and Hisham Matar",
+              "credit": "Photograph: Murdo Macleod for the Guardian",
+              "photographer": "Murdo Macleod",
+              "source": "The Guardian",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a/10_0_3367_2021/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "1d4b7b3621415ad3b3015c4e29d941cf7fc8666a",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/1d4b7b3621415ad3b3015c4e29d941cf7fc8666a"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "sustainable-business/2016/nov/12/donald-trump-climate-change-energy-environment",
+    "type": "article",
+    "sectionId": "sustainable-business",
+    "sectionName": "Guardian Sustainable Business",
+    "webPublicationDate": "2016-11-12T13:00:50Z",
+    "webTitle": "Trump's influence on the future of clean energy is less clear than you think",
+    "webUrl": "https://www.theguardian.com/sustainable-business/2016/nov/12/donald-trump-climate-change-energy-environment",
+    "apiUrl": "https://content.guardianapis.com/sustainable-business/2016/nov/12/donald-trump-climate-change-energy-environment",
+    "fields": {
+      "standfirst": "<p>The president-elect is a political novice whose energy plan doesn’t account for the economic reality of coal and renewable energy</p>"
+    },
+    "elements": [
+      {
+        "id": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/2000.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/1000.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/500.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/140.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/5266.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "5266",
+              "height": "3160",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/5266.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/master/5266.jpg",
+            "typeData": {
+              "altText": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "caption": "Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment.",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "5266",
+              "height": "3160",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/master/5266.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      },
+      {
+        "id": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/master/5266.jpg",
+            "typeData": {
+              "altText": "Donald Trump<br>U.S. President-elect Donald Trump smiles as he arrives to speak at an election night rally, early Wednesday, Nov. 9, 2016, in New York. Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment. But they’re concerned that gridlock will continue in Washington even though there will be a Republican president and a Congress that looks to be GOP-dominated. (AP Photo/ Evan Vucci)",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "5266",
+              "height": "3160",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/master/5266.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/5266.jpg",
+            "typeData": {
+              "altText": "Donald Trump<br>U.S. President-elect Donald Trump smiles as he arrives to speak at an election night rally, early Wednesday, Nov. 9, 2016, in New York. Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment. But they’re concerned that gridlock will continue in Washington even though there will be a Republican president and a Congress that looks to be GOP-dominated. (AP Photo/ Evan Vucci)",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "5266",
+              "height": "3160",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/5266.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/500.jpg",
+            "typeData": {
+              "altText": "Donald Trump<br>U.S. President-elect Donald Trump smiles as he arrives to speak at an election night rally, early Wednesday, Nov. 9, 2016, in New York. Trump’s election has small business advocates expecting changes in government policy on issues like health care and the environment. But they’re concerned that gridlock will continue in Washington even though there will be a Republican president and a Congress that looks to be GOP-dominated. (AP Photo/ Evan Vucci)",
+              "credit": "Photograph: Evan Vucci/AP",
+              "photographer": "Evan Vucci",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b4f8562cced9675c7165f2c19febf1f3cd4a312d/0_31_5266_3160/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ307",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b4f8562cced9675c7165f2c19febf1f3cd4a312d",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/how-to-prepare-for-donald-trump-presidency",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T12:30:49Z",
+    "webTitle": "Citizen solutions: things you can do now to prepare for the worst under Trump",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/how-to-prepare-for-donald-trump-presidency",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/how-to-prepare-for-donald-trump-presidency",
+    "fields": {
+      "standfirst": "<p>Trump’s campaign was light on policy details, so activists have already organized everything from classes to safe houses to prepare for what may happen</p>"
+    },
+    "elements": [
+      {
+        "id": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/2000.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/1000.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/500.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/140.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/3714.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "3714",
+              "height": "2230",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/3714.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/master/3714.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "caption": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "3714",
+              "height": "2230",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/master/3714.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          }
+        ]
+      },
+      {
+        "id": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/master/3714.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "3714",
+              "height": "2230",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/master/3714.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/3714.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "3714",
+              "height": "2230",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/3714.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/500.jpg",
+            "typeData": {
+              "altText": "Want to have an impact on future elections? Move to a swing state.",
+              "credit": "Photograph: Wilfredo Lee/AP",
+              "photographer": "Wilfredo Lee",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/3ac939dcc9a1fe4657d4b737d58442d74f56e16b/0_0_3714_2230/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "3ac939dcc9a1fe4657d4b737d58442d74f56e16b",
+              "imageType": "Photograph",
+              "suppliersReference": "NYBZ498",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/3ac939dcc9a1fe4657d4b737d58442d74f56e16b"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "lifeandstyle/2016/nov/12/how-to-talk-to-strangers",
+    "type": "article",
+    "sectionId": "lifeandstyle",
+    "sectionName": "Life and style",
+    "webPublicationDate": "2016-11-12T12:30:49Z",
+    "webTitle": "How to talk to strangers: a guide to bridging what divides us",
+    "webUrl": "https://www.theguardian.com/lifeandstyle/2016/nov/12/how-to-talk-to-strangers",
+    "apiUrl": "https://content.guardianapis.com/lifeandstyle/2016/nov/12/how-to-talk-to-strangers",
+    "fields": {
+      "standfirst": "<p>The more we do to interact with people who aren’t like us, the better off we’ll be in the face of hatred that has become so visible thanks to Donald Trump</p>"
+    },
+    "elements": [
+      {
+        "id": "dba3053984b608d223bc5f232eee008b887397df",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/2000.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/1000.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/500.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/140.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/4200.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/4200.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/master/4200.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "caption": "A fleeting alliance at the grocery store.",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/master/4200.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a0caf057af119703961924012791ed2f157e30c9",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/4200.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/4200.jpg",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/master/4200.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/master/4200.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/2000.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/1000.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/500.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/140.jpg",
+            "typeData": {
+              "altText": "“Republicans and Democrats have always been on opposite sides of political and social fences. What’s new, what might feel insurmountable is the degree of difference.”",
+              "caption": "‘Republicans and Democrats have always been on opposite sides of political and social fences. What’s new is the <em>degree</em> of difference.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/a0caf057af119703961924012791ed2f157e30c9/0_278_4200_2520/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "a0caf057af119703961924012791ed2f157e30c9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a0caf057af119703961924012791ed2f157e30c9"
+            }
+          }
+        ]
+      },
+      {
+        "id": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/4100.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4100",
+              "height": "2461",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/4100.jpg",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/master/4100.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4100",
+              "height": "2461",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/master/4100.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/2000.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/1000.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/500.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/140.jpg",
+            "typeData": {
+              "altText": "“Researchers at MIT found that our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships, and more than our online lives.”",
+              "caption": "‘Our interactions in physical space with peers have a much more significant effect on our beliefs and opinions than any other relationships.’",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/9ef288df40fcd562f584f6625625655d8cc83a0b/0_352_4100_2461/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "9ef288df40fcd562f584f6625625655d8cc83a0b",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/9ef288df40fcd562f584f6625625655d8cc83a0b"
+            }
+          }
+        ]
+      },
+      {
+        "id": "dba3053984b608d223bc5f232eee008b887397df",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/master/4200.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/master/4200.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/4200.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "4200",
+              "height": "2520",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/4200.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/500.jpg",
+            "typeData": {
+              "altText": "Grocery store",
+              "credit": "Photograph: Julia Rothman",
+              "source": "Julia Rothman",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/dba3053984b608d223bc5f232eee008b887397df/0_306_4200_2520/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "dba3053984b608d223bc5f232eee008b887397df",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/dba3053984b608d223bc5f232eee008b887397df"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "world/2016/nov/12/afghanistan-suicide-bomb-kills-at-least-four-at-bagram-airbase",
+    "type": "article",
+    "sectionId": "world",
+    "sectionName": "World news",
+    "webPublicationDate": "2016-11-12T12:03:24Z",
+    "webTitle": "Afghanistan suicide bomb kills at least four at Bagram airbase",
+    "webUrl": "https://www.theguardian.com/world/2016/nov/12/afghanistan-suicide-bomb-kills-at-least-four-at-bagram-airbase",
+    "apiUrl": "https://content.guardianapis.com/world/2016/nov/12/afghanistan-suicide-bomb-kills-at-least-four-at-bagram-airbase",
+    "fields": {
+      "standfirst": "<p>Taliban claim responsibility for attack in which suicide bomber dressed labourer blew himself up at Nato airfield</p>"
+    },
+    "elements": [
+      {
+        "id": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/2000.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/1000.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/140.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/3500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2101",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/3500.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/master/3500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "caption": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2101",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/master/3500.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          }
+        ]
+      },
+      {
+        "id": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/master/3500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2101",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/master/3500.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/3500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "3500",
+              "height": "2101",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/3500.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/500.jpg",
+            "typeData": {
+              "altText": "Afghan National Army soldiers keep watch outside the Bagram airfield entrance gate following the attack.",
+              "credit": "Photograph: Omar Sobhani/Reuters",
+              "photographer": "Omar Sobhani",
+              "source": "Reuters",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/edd7b0f270c6cb86cc3459c01c7eca715029e565/0_431_3500_2101/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "edd7b0f270c6cb86cc3459c01c7eca715029e565",
+              "imageType": "Photograph",
+              "suppliersReference": "GGGKAB103",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/edd7b0f270c6cb86cc3459c01c7eca715029e565"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "science/political-science/2016/nov/12/who-are-experts-anyway",
+    "type": "article",
+    "sectionId": "science",
+    "sectionName": "Science",
+    "webPublicationDate": "2016-11-12T12:00:48Z",
+    "webTitle": "Who are ‘experts’, anyway?",
+    "webUrl": "https://www.theguardian.com/science/political-science/2016/nov/12/who-are-experts-anyway",
+    "apiUrl": "https://content.guardianapis.com/science/political-science/2016/nov/12/who-are-experts-anyway",
+    "fields": {
+      "standfirst": "<p>In the latest post in a series on experts, <strong>Reiner Grundmann</strong> argues that even in the world of Brexit and President Trump expertise is alive and well. However, we must pay close attention to how it is used in politics.</p>"
+    },
+    "elements": [
+      {
+        "id": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/2000.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/1000.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/500.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/140.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/5192.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "5192",
+              "height": "3117",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/5192.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/master/5192.jpg",
+            "typeData": {
+              "altText": "Expertise is everywhere. ",
+              "caption": "Expertise is everywhere. ",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "5192",
+              "height": "3117",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/master/5192.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          }
+        ]
+      },
+      {
+        "id": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/master/5192.jpg",
+            "typeData": {
+              "altText": "Male doctor holding a stethoscope towards the camera<br>GettyImages-84022540",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "5192",
+              "height": "3117",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/master/5192.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/5192.jpg",
+            "typeData": {
+              "altText": "Male doctor holding a stethoscope towards the camera<br>GettyImages-84022540",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "5192",
+              "height": "3117",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/5192.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/500.jpg",
+            "typeData": {
+              "altText": "Male doctor holding a stethoscope towards the camera<br>GettyImages-84022540",
+              "credit": "Photograph: I Love Images/Getty Images/Cultura RF",
+              "photographer": "I Love Images",
+              "source": "Getty Images/Cultura RF",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/d8299b0df6f73f01b7bf4540b382c818da9f741d/0_0_5192_3117/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "imageType": "Photograph",
+              "suppliersReference": "84022540",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d8299b0df6f73f01b7bf4540b382c818da9f741d",
+              "copyright": "This content is subject to copyright."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/donald-trump-conflicts-of-interest-business",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T12:00:48Z",
+    "webTitle": "Trump's conflicts of interest take White House into uncharted territory",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/donald-trump-conflicts-of-interest-business",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/donald-trump-conflicts-of-interest-business",
+    "fields": {
+      "standfirst": "<p>With his children, and not a blind trust, running his company, little prevents the president-elect’s political and business careers from bleeding into each other</p>"
+    },
+    "elements": [
+      {
+        "id": "542149bb5324410de46eb72e3e5a23258bea24b0",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/2000.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/1000.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/500.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/140.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/4248.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "4248",
+              "height": "2549",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/4248.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/master/4248.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "caption": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "4248",
+              "height": "2549",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/master/4248.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          }
+        ]
+      },
+      {
+        "id": "542149bb5324410de46eb72e3e5a23258bea24b0",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/master/4248.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "4248",
+              "height": "2549",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/master/4248.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/4248.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "4248",
+              "height": "2549",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/4248.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/500.jpg",
+            "typeData": {
+              "altText": "Donald Trump has said his business interests will be administered by his children, left to right, Donald Jr, Eric and Ivanka, who are also part of his transition team.",
+              "credit": "Photograph: Oli Scarff/AFP/Getty Images",
+              "photographer": "Oli Scarff",
+              "source": "AFP/Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/542149bb5324410de46eb72e3e5a23258bea24b0/0_142_4248_2549/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "542149bb5324410de46eb72e3e5a23258bea24b0",
+              "imageType": "Photograph",
+              "suppliersReference": "AFP_I094Q",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/542149bb5324410de46eb72e3e5a23258bea24b0",
+              "copyright": "AFP or licensors"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "football/2016/nov/12/mexico-united-states-donald-trump-rafael-marquez",
+    "type": "article",
+    "sectionId": "football",
+    "sectionName": "Football",
+    "webPublicationDate": "2016-11-12T11:33:54Z",
+    "webTitle": "Rafael Márquez says win over USA will help Mexico at time of intolerance",
+    "webUrl": "https://www.theguardian.com/football/2016/nov/12/mexico-united-states-donald-trump-rafael-marquez",
+    "apiUrl": "https://content.guardianapis.com/football/2016/nov/12/mexico-united-states-donald-trump-rafael-marquez",
+    "fields": {
+      "standfirst": "• President-elect Donald Trump accused Mexicans of being rapists<br />• Márquez: ‘Mexicans can forget a little about what happened’"
+    },
+    "elements": [
+      {
+        "id": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1000.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "caption": "Rafael Márquez, left, and team-mates celebrate following victory against the United States at the Mapfre Stadium. ",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/500.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "caption": "Rafael Márquez, left, and team-mates celebrate following victory against the United States at the Mapfre Stadium. ",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/140.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "caption": "Rafael Márquez, left, and team-mates celebrate following victory against the United States at the Mapfre Stadium. ",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1657.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "caption": "Rafael Márquez, left, and team-mates celebrate following victory against the United States at the Mapfre Stadium. ",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "1657",
+              "height": "994",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1657.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/master/1657.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "caption": "Rafael Márquez, left, and team-mates celebrate following victory against the United States at the Mapfre Stadium. ",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "1657",
+              "height": "994",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/master/1657.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/master/1657.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "1657",
+              "height": "994",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/master/1657.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1657.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "1657",
+              "height": "994",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/1657.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/500.jpg",
+            "typeData": {
+              "altText": "Rafael Márquez",
+              "credit": "Photograph: Joseph Maiorana/USA Today Sports",
+              "photographer": "Joseph Maiorana",
+              "source": "USA Today Sports",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6a19cfcab4226f2003fdcb9a79b453289529335b/210_147_1657_994/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "imageType": "Photograph",
+              "suppliersReference": "USATSI-348626",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6a19cfcab4226f2003fdcb9a79b453289529335b",
+              "copyright": "USA Today Sports"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "us-news/2016/nov/12/latino-leader-attacks-clinton-campaign-hispanic-vote",
+    "type": "article",
+    "sectionId": "us-news",
+    "sectionName": "US news",
+    "webPublicationDate": "2016-11-12T11:30:48Z",
+    "webTitle": "Latino leader attacks Clinton campaign for taking Hispanic vote for granted",
+    "webUrl": "https://www.theguardian.com/us-news/2016/nov/12/latino-leader-attacks-clinton-campaign-hispanic-vote",
+    "apiUrl": "https://content.guardianapis.com/us-news/2016/nov/12/latino-leader-attacks-clinton-campaign-hispanic-vote",
+    "fields": {
+      "standfirst": "<ul><li>Hispanic business leader regrets decision not to name Latino running mate</li><li>Clinton campaign disputes exit polls that say 29% of Latinos voted for Trump</li></ul>"
+    },
+    "elements": [
+      {
+        "id": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/140.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/500.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/1000.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/2000.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/5178.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "5178",
+              "height": "3107",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/5178.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/master/5178.jpg",
+            "typeData": {
+              "altText": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "caption": "Latino supporters of Hillary Clinton hold a sign saying ‘I’m with her’ written in Spanish at a campaign rally in Miami, Florida, in July.",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "5178",
+              "height": "3107",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_42_5178_3107/master/5178.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          }
+        ]
+      },
+      {
+        "id": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/master/5178.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton Introduces Tim Kaine As Vice Presidential Nominee<br>MIAMI, FL - JULY 23: Latino supporters of Democratic presidential candidate former Secretary of State Hillary Clinton hold a sign saying “I’m with her” written in Spanish at a campaign rally, July 23, 2016 in Miami, Florida. (Photo by Brooks Kraft/Getty Images)",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "5178",
+              "height": "3107",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/master/5178.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/5178.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton Introduces Tim Kaine As Vice Presidential Nominee<br>MIAMI, FL - JULY 23: Latino supporters of Democratic presidential candidate former Secretary of State Hillary Clinton hold a sign saying “I’m with her” written in Spanish at a campaign rally, July 23, 2016 in Miami, Florida. (Photo by Brooks Kraft/Getty Images)",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "5178",
+              "height": "3107",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/5178.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/500.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton Introduces Tim Kaine As Vice Presidential Nominee<br>MIAMI, FL - JULY 23: Latino supporters of Democratic presidential candidate former Secretary of State Hillary Clinton hold a sign saying “I’m with her” written in Spanish at a campaign rally, July 23, 2016 in Miami, Florida. (Photo by Brooks Kraft/Getty Images)",
+              "credit": "Photograph: Brooks Kraft/Getty Images",
+              "photographer": "Brooks Kraft",
+              "source": "Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/b2a5b2a2b7e42facc177e4254c15454870f9037b/0_58_5178_3107/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "imageType": "Photograph",
+              "suppliersReference": "657859885",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/b2a5b2a2b7e42facc177e4254c15454870f9037b",
+              "copyright": "2016 Brooks Kraft"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "books/2016/nov/12/hillary-clinton-we-failed-her-sarah-churchwell",
+    "type": "article",
+    "sectionId": "books",
+    "sectionName": "Books",
+    "webPublicationDate": "2016-11-12T11:01:54Z",
+    "webTitle": "‘Hillary Clinton didn’t fail us. We failed her’",
+    "webUrl": "https://www.theguardian.com/books/2016/nov/12/hillary-clinton-we-failed-her-sarah-churchwell",
+    "apiUrl": "https://content.guardianapis.com/books/2016/nov/12/hillary-clinton-we-failed-her-sarah-churchwell",
+    "fields": {
+      "standfirst": "<p>Sarah Churchwell examines the myths, stories and misogyny surrounding American women and power</p><p> • <a href=\"https://www.theguardian.com/books/2016/nov/12/we-are-witnessing-the-politics-of-humiliation-siri-hustvedt-joyce-carol-oates-and-more-on-the-us-election\">‘We are witnessing the politics of humiliation’ – Siri Hustvedt, Joyce Carol Oates and more on the US election</a><br></p>"
+    },
+    "elements": [
+      {
+        "id": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2000.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/1000.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/500.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/140.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2746.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "2746",
+              "height": "1647",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2746.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/master/2746.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "caption": "The election was fought over a series of fictions, myths and outright lies … Hillary Clinton walks off stage after a rally.",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "2746",
+              "height": "1647",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/master/2746.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          }
+        ]
+      },
+      {
+        "id": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/3883.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "3883",
+              "height": "2330",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/3883.jpg",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/master/3883.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "3883",
+              "height": "2330",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/master/3883.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/2000.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/1000.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/500.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/140.jpg",
+            "typeData": {
+              "altText": "Margaret Chase Smith",
+              "caption": "Margaret Chase Smith, the first woman elected to the Senate who had not inherited the seat from a man.",
+              "credit": "Photograph: Bettmann Archive",
+              "source": "Bettmann Archive",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b/0_291_3883_2330/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "imageType": "Photograph",
+              "suppliersReference": "UKD1122INP",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/530f2f13d5e6adbafc5ff9862d84bcf6c0db579b",
+              "copyright": "This content is subject to copyright."
+            }
+          }
+        ]
+      },
+      {
+        "id": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/5760.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "5760",
+              "height": "3456",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/5760.jpg",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/master/5760.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "5760",
+              "height": "3456",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/master/5760.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/2000.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/1000.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/500.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/140.jpg",
+            "typeData": {
+              "altText": "ulia Louis-Dreyfus Veep",
+              "caption": "‘Her best hope was to be disliked and crooked, but at least she’d be president’ … Julia Louis-Dreyfus in<em> Veep.</em>",
+              "credit": "Photograph: HBO",
+              "source": "HBO",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/7357796ebd8e4f8c0028bfa1468210884bff19b5/0_384_5760_3456/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7357796ebd8e4f8c0028bfa1468210884bff19b5",
+              "copyright": "© HBO"
+            }
+          }
+        ]
+      },
+      {
+        "id": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/master/2746.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "2746",
+              "height": "1647",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/master/2746.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2746.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "2746",
+              "height": "1647",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/2746.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/500.jpg",
+            "typeData": {
+              "altText": "Hillary Clinton",
+              "credit": "Photograph: Justin Sullivan/Getty Images",
+              "photographer": "Justin Sullivan",
+              "source": "Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/a5161e1df1f24b7ed1ebee32866338f339d9d6ee/229_351_2746_1647/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "imageType": "Photograph",
+              "suppliersReference": "680379257",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a5161e1df1f24b7ed1ebee32866338f339d9d6ee",
+              "copyright": "2016 Getty Images"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "sport/willstrop-s-world/2016/nov/12/nick-kyrgios-sport-tennis-disrepute-bad-behaviour-golf-squash-cricket",
+    "type": "article",
+    "sectionId": "sport",
+    "sectionName": "Sport",
+    "webPublicationDate": "2016-11-12T10:00:46Z",
+    "webTitle": "Nick Kyrgios is rebuked for bringing sport 'into disrepute' but fans love a rebel",
+    "webUrl": "https://www.theguardian.com/sport/willstrop-s-world/2016/nov/12/nick-kyrgios-sport-tennis-disrepute-bad-behaviour-golf-squash-cricket",
+    "apiUrl": "https://content.guardianapis.com/sport/willstrop-s-world/2016/nov/12/nick-kyrgios-sport-tennis-disrepute-bad-behaviour-golf-squash-cricket",
+    "fields": {
+      "standfirst": "<p>John McEnroe enraged some stuffier tennis fans but it hasn’t hurt his career. A little bit of bad behaviour can be a delicious thing in sporting combat</p><p>By <a href=\"https://twitter.com/james_willstrop\">James Willstrop</a> for <a href=\"http://www.willstrop.co.uk/\">Willstrop’s World</a>, part of the <a href=\"https://www.theguardian.com/sport/series/guardian-sport-network\">Guardian Sport Network</a></p>"
+    },
+    "elements": [
+      {
+        "id": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/2000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/1000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/500.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/140.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/3000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "3000",
+              "height": "1800",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/3000.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/master/3000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "caption": "Nick Kyrgios remonstrated with the umpire and was booed by the crowd during his listless defeat to Gael Monfils at the Japan Open.",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "3000",
+              "height": "1800",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/master/3000.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      },
+      {
+        "id": "a873896bee18ea5b2768d61ac4e438084e666947",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/1852.jpg",
+            "typeData": {
+              "altText": "John McEnroe",
+              "caption": "John McEnroe was never short of an opinion but his career has survived.",
+              "credit": "Photograph: PA",
+              "photographer": "PA",
+              "source": "PA",
+              "width": "1852",
+              "height": "1293",
+              "secureFile": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/1852.jpg",
+              "displayCredit": "true",
+              "mediaId": "a873896bee18ea5b2768d61ac4e438084e666947",
+              "imageType": "Photograph",
+              "suppliersReference": "TENNIS_Murray_Number_Ones_170461",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a873896bee18ea5b2768d61ac4e438084e666947",
+              "copyright": "PA Wire"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/master/1852.jpg",
+            "typeData": {
+              "altText": "John McEnroe",
+              "caption": "John McEnroe was never short of an opinion but his career has survived.",
+              "credit": "Photograph: PA",
+              "photographer": "PA",
+              "source": "PA",
+              "width": "1852",
+              "height": "1293",
+              "secureFile": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/master/1852.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "a873896bee18ea5b2768d61ac4e438084e666947",
+              "imageType": "Photograph",
+              "suppliersReference": "TENNIS_Murray_Number_Ones_170461",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a873896bee18ea5b2768d61ac4e438084e666947",
+              "copyright": "PA Wire"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/1000.jpg",
+            "typeData": {
+              "altText": "John McEnroe",
+              "caption": "John McEnroe was never short of an opinion but his career has survived.",
+              "credit": "Photograph: PA",
+              "photographer": "PA",
+              "source": "PA",
+              "width": "1000",
+              "height": "698",
+              "secureFile": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "a873896bee18ea5b2768d61ac4e438084e666947",
+              "imageType": "Photograph",
+              "suppliersReference": "TENNIS_Murray_Number_Ones_170461",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a873896bee18ea5b2768d61ac4e438084e666947",
+              "copyright": "PA Wire"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/500.jpg",
+            "typeData": {
+              "altText": "John McEnroe",
+              "caption": "John McEnroe was never short of an opinion but his career has survived.",
+              "credit": "Photograph: PA",
+              "photographer": "PA",
+              "source": "PA",
+              "width": "500",
+              "height": "349",
+              "secureFile": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "a873896bee18ea5b2768d61ac4e438084e666947",
+              "imageType": "Photograph",
+              "suppliersReference": "TENNIS_Murray_Number_Ones_170461",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a873896bee18ea5b2768d61ac4e438084e666947",
+              "copyright": "PA Wire"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/140.jpg",
+            "typeData": {
+              "altText": "John McEnroe",
+              "caption": "John McEnroe was never short of an opinion but his career has survived.",
+              "credit": "Photograph: PA",
+              "photographer": "PA",
+              "source": "PA",
+              "width": "140",
+              "height": "98",
+              "secureFile": "https://media.guim.co.uk/a873896bee18ea5b2768d61ac4e438084e666947/0_0_1852_1293/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "a873896bee18ea5b2768d61ac4e438084e666947",
+              "imageType": "Photograph",
+              "suppliersReference": "TENNIS_Murray_Number_Ones_170461",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/a873896bee18ea5b2768d61ac4e438084e666947",
+              "copyright": "PA Wire"
+            }
+          }
+        ]
+      },
+      {
+        "id": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/master/3000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "3000",
+              "height": "1800",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/master/3000.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/3000.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "3000",
+              "height": "1800",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/3000.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/500.jpg",
+            "typeData": {
+              "altText": "Nick Kyrgios",
+              "credit": "Photograph: Koji Sasahara/AP",
+              "photographer": "Koji Sasahara",
+              "source": "AP",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/821c24e29edb368a5647a34dd3bab2f146afbb66/0_0_3000_1800/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "imageType": "Photograph",
+              "suppliersReference": "NY153",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/821c24e29edb368a5647a34dd3bab2f146afbb66",
+              "copyright": "Copyright 2016 The Associated Press. All rights reserved."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "sport/2016/nov/12/conor-mcgregor-ufc-new-york-madison-square-garden",
+    "type": "article",
+    "sectionId": "sport",
+    "sectionName": "Sport",
+    "webPublicationDate": "2016-11-12T09:00:45Z",
+    "webTitle": "All eyes on Conor McGregor as UFC makes its return to New York",
+    "webUrl": "https://www.theguardian.com/sport/2016/nov/12/conor-mcgregor-ufc-new-york-madison-square-garden",
+    "apiUrl": "https://content.guardianapis.com/sport/2016/nov/12/conor-mcgregor-ufc-new-york-madison-square-garden",
+    "fields": {
+      "standfirst": "<p>Fans at Madison Square Garden for UFC 205 will walk through the doors expecting the best that MMA can offer, and on paper, at least, they should get it</p>"
+    },
+    "elements": [
+      {
+        "id": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/140.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/500.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/1000.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/2000.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/3171.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3171",
+              "height": "1903",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/3171.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/master/3171.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "caption": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3171",
+              "height": "1903",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/master/3171.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          }
+        ]
+      },
+      {
+        "id": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/3298.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3298",
+              "height": "2196",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/3298.jpg",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/master/3298.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3298",
+              "height": "2196",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/master/3298.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/2000.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "2000",
+              "height": "1332",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/1000.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "1000",
+              "height": "666",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/500.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "500",
+              "height": "333",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/140.jpg",
+            "typeData": {
+              "altText": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "caption": "Tyron Woodley and Stephen Thompson face off during the UFC 205 press conference.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari/Zuffa LLC",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "140",
+              "height": "93",
+              "secureFile": "https://media.guim.co.uk/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a/0_0_3298_2196/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "imageType": "Photograph",
+              "suppliersReference": "622166046",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/7cfc7fd11cfb6aed04287abc4cd5e5becf58ba5a",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          }
+        ]
+      },
+      {
+        "id": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/master/3171.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3171",
+              "height": "1903",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/master/3171.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/3171.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "3171",
+              "height": "1903",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/3171.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/500.jpg",
+            "typeData": {
+              "altText": "McGregor, the sport’s biggest attraction, goes up against one of its toughest competitors, Philadelphia’s Eddie Alvarez.",
+              "credit": "Photograph: Jeff Bottari/Zuffa LLC via Getty Images",
+              "photographer": "Jeff Bottari",
+              "source": "Zuffa LLC via Getty Images",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84/0_26_3171_1903/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "imageType": "Photograph",
+              "suppliersReference": "622165786",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/8470d4a7b0bf1729e6a7ff54aa871c5616ba3a84",
+              "copyright": "2016 Jeff Bottari/Zuffa LLC"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "membership/2016/nov/12/weekend-reading-troll-hunting-aspergers-comedy-and-the-trump-forecast",
+    "type": "article",
+    "sectionId": "membership",
+    "sectionName": "Membership",
+    "webPublicationDate": "2016-11-12T08:10:44Z",
+    "webTitle": "Weekend reading: Troll hunting, Asperger's comedy and the Trump forecast",
+    "webUrl": "https://www.theguardian.com/membership/2016/nov/12/weekend-reading-troll-hunting-aspergers-comedy-and-the-trump-forecast",
+    "apiUrl": "https://content.guardianapis.com/membership/2016/nov/12/weekend-reading-troll-hunting-aspergers-comedy-and-the-trump-forecast",
+    "fields": {
+      "standfirst": "<p> Why Prince Harry’s fellow millennials must not ignore online abuse, why comic troupe Asperger’s Are Us don’t want your pity, and why there’s nothing to restrain the next US president</p>"
+    },
+    "elements": [
+      {
+        "id": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/140.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/500.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/1000.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/2000.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/5565.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "5565",
+              "height": "3340",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/5565.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/master/5565.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/Finbarr Webster/Rex/Shutterstock",
+              "photographer": "Finbarr Webster",
+              "source": "Finbarr Webster/Rex/Shutterstock",
+              "width": "5565",
+              "height": "3340",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/master/5565.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          }
+        ]
+      },
+      {
+        "id": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/5425.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "5425",
+              "height": "3254",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/5425.jpg",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/master/5425.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "5425",
+              "height": "3254",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/master/5425.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/2000.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/1000.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/500.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/140.jpg",
+            "typeData": {
+              "altText": "SNCC staff sit-in at a Toddle House.",
+              "credit": "Photograph: Danny Lyon/Magnum Photos",
+              "photographer": "Danny Lyon",
+              "source": "Magnum Photos",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f/469_334_5425_3254/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "imageType": "Photograph",
+              "suppliersReference": "LYD1962011W00013/12",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/bd5f801f29a586e93f68c5366b0f6b0f3eea1d2f",
+              "copyright": "©Danny Lyon / Magnum Photos"
+            }
+          }
+        ]
+      },
+      {
+        "id": "22a8914f49670c6bfe9bad888956015a897b43b9",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/2199.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "2199",
+              "height": "1319",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/2199.jpg",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/master/2199.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "2199",
+              "height": "1319",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/master/2199.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/2000.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/1000.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/500.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/140.jpg",
+            "typeData": {
+              "altText": "Amazon Dash button boxes",
+              "credit": "Photograph: Samuel Gibbs for the Guardian",
+              "photographer": "Samuel Gibbs",
+              "source": "The Guardian",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/22a8914f49670c6bfe9bad888956015a897b43b9/1_0_2199_1319/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "22a8914f49670c6bfe9bad888956015a897b43b9",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/22a8914f49670c6bfe9bad888956015a897b43b9"
+            }
+          }
+        ]
+      },
+      {
+        "id": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/1242.jpg",
+            "typeData": {
+              "altText": "Maganbhai Patel photographer",
+              "credit": "Photograph: Maganbhai Patel",
+              "source": "Maganbhai Patel",
+              "width": "1242",
+              "height": "744",
+              "secureFile": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/1242.jpg",
+              "displayCredit": "true",
+              "mediaId": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d14b609909df46fc4fef0473b8a262db57c4d7cd"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/master/1242.jpg",
+            "typeData": {
+              "altText": "Maganbhai Patel photographer",
+              "credit": "Photograph: Maganbhai Patel",
+              "source": "Maganbhai Patel",
+              "width": "1242",
+              "height": "744",
+              "secureFile": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/master/1242.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d14b609909df46fc4fef0473b8a262db57c4d7cd"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/1000.jpg",
+            "typeData": {
+              "altText": "Maganbhai Patel photographer",
+              "credit": "Photograph: Maganbhai Patel",
+              "source": "Maganbhai Patel",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d14b609909df46fc4fef0473b8a262db57c4d7cd"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/500.jpg",
+            "typeData": {
+              "altText": "Maganbhai Patel photographer",
+              "credit": "Photograph: Maganbhai Patel",
+              "source": "Maganbhai Patel",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d14b609909df46fc4fef0473b8a262db57c4d7cd"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/140.jpg",
+            "typeData": {
+              "altText": "Maganbhai Patel photographer",
+              "credit": "Photograph: Maganbhai Patel",
+              "source": "Maganbhai Patel",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/d14b609909df46fc4fef0473b8a262db57c4d7cd/144_265_1242_744/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "d14b609909df46fc4fef0473b8a262db57c4d7cd",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/d14b609909df46fc4fef0473b8a262db57c4d7cd"
+            }
+          }
+        ]
+      },
+      {
+        "id": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+        "relation": "body",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/5792.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "5792",
+              "height": "3475",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/5792.jpg",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/master/5792.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "5792",
+              "height": "3475",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/master/5792.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/2000.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "2000",
+              "height": "1200",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/2000.jpg",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/1000.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "1000",
+              "height": "600",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/1000.jpg",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/500.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/140.jpg",
+            "typeData": {
+              "altText": "Anna Jones' rye bread",
+              "credit": "Photograph: Matt Russell for the Guardian",
+              "photographer": "Matt Russell",
+              "source": "The Guardian",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/f525c362445b61ffa03bf95af7404f3dfc13e112/0_4793_5792_3475/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "f525c362445b61ffa03bf95af7404f3dfc13e112",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/f525c362445b61ffa03bf95af7404f3dfc13e112"
+            }
+          }
+        ]
+      },
+      {
+        "id": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/master/5565.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/REX/Shutterstock",
+              "photographer": "Finbarr Webster/REX/Shutterstock",
+              "source": "Finbarr Webster/REX/Shutterstock",
+              "width": "5565",
+              "height": "3340",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/master/5565.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/5565.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/REX/Shutterstock",
+              "photographer": "Finbarr Webster/REX/Shutterstock",
+              "source": "Finbarr Webster/REX/Shutterstock",
+              "width": "5565",
+              "height": "3340",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/5565.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/500.jpg",
+            "typeData": {
+              "altText": "UK newspaper front pages",
+              "credit": "Photograph: Finbarr Webster/REX/Shutterstock",
+              "photographer": "Finbarr Webster/REX/Shutterstock",
+              "source": "Finbarr Webster/REX/Shutterstock",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/5ff14f2ae86693a613bdbc2db61194edba70e51c/19_194_5565_3340/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "imageType": "Photograph",
+              "suppliersReference": "7429399m",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/5ff14f2ae86693a613bdbc2db61194edba70e51c",
+              "copyright": "Copyright (c) 2016 Rex Features. No use without permission."
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  },
+  {
+    "id": "film/2016/nov/12/the-comedian-review-de-niro-leslie-mann-afi",
+    "type": "article",
+    "sectionId": "film",
+    "sectionName": "Film",
+    "webPublicationDate": "2016-11-12T08:08:09Z",
+    "webTitle": "The Comedian review – De Niro delivers as standup who's sick of life's punchlines",
+    "webUrl": "https://www.theguardian.com/film/2016/nov/12/the-comedian-review-de-niro-leslie-mann-afi",
+    "apiUrl": "https://content.guardianapis.com/film/2016/nov/12/the-comedian-review-de-niro-leslie-mann-afi",
+    "fields": {
+      "standfirst": "<p>De Niro’s turn as a misanthropic weather-beaten comic who can’t seem to shake his annoying alter-ego, mixes Bad Grandpa’s puerile pathos and Louie’s darkness</p>"
+    },
+    "elements": [
+      {
+        "id": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+        "relation": "main",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/500.jpg",
+            "typeData": {
+              "altText": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "caption": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/140.jpg",
+            "typeData": {
+              "altText": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "caption": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "140",
+              "height": "84",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/140.jpg",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/689.jpg",
+            "typeData": {
+              "altText": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "caption": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "689",
+              "height": "413",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/689.jpg",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          },
+          {
+            "type": "image",
+            "mimeType": "image/jpeg",
+            "file": "http://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/master/689.jpg",
+            "typeData": {
+              "altText": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "caption": "Don’t call him Eddie: Leslie Mann and Robert De niro in The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "689",
+              "height": "413",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/master/689.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          }
+        ]
+      },
+      {
+        "id": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+        "relation": "thumbnail",
+        "type": "image",
+        "assets": [
+          {
+            "type": "image",
+            "file": "http://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/master/689.jpg",
+            "typeData": {
+              "altText": "The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "689",
+              "height": "413",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/master/689.jpg",
+              "isMaster": "true",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/689.jpg",
+            "typeData": {
+              "altText": "The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "689",
+              "height": "413",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/689.jpg",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          },
+          {
+            "type": "image",
+            "file": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/500.jpg",
+            "typeData": {
+              "altText": "The Comedian",
+              "credit": "Photograph: AFI",
+              "source": "AFI",
+              "width": "500",
+              "height": "300",
+              "secureFile": "https://media.guim.co.uk/6282c5ccbc8ca94de068a71f49fece2fbb17c770/2_42_689_413/500.jpg",
+              "displayCredit": "true",
+              "mediaId": "6282c5ccbc8ca94de068a71f49fece2fbb17c770",
+              "imageType": "Photograph",
+              "mediaApiUri": "https://api.media.gutools.co.uk/images/6282c5ccbc8ca94de068a71f49fece2fbb17c770"
+            }
+          }
+        ]
+      }
+    ],
+    "isHosted": false
+  }
+]

--- a/src/test/resources/facebookRequests/trumpHeadlines.json
+++ b/src/test/resources/facebookRequests/trumpHeadlines.json
@@ -16,7 +16,7 @@
           "message":{
             "mid":"mid.1457764197618:41d102a3e1ae206a38",
             "seq":73,
-            "text":"some headlines please"
+            "text":"some news on Donald Trump please"
           }
         }
       ]

--- a/src/test/resources/facebookResponses/trumpHeadlines.json
+++ b/src/test/resources/facebookResponses/trumpHeadlines.json
@@ -1,0 +1,132 @@
+[
+  {
+    "recipient":{
+      "id":"headlines_test"
+    },
+    "message":{
+      "text":"I think you're asking me about Donald Trump. Here are some articles that could be of interest:",
+      "attachment":null,
+      "quick_replies":null,
+      "metadata":null
+    },
+    "sender_action":null,
+    "notification_type":null
+  },
+  {
+    "recipient":{
+      "id":"headlines_test"
+    },
+    "message":{
+      "text":null,
+      "attachment":{
+        "type":"template",
+        "payload":{
+          "template_type":"generic",
+          "text":null,
+          "elements":[
+            {
+              "title":"Suicide hotline calls reached record high as Trump victory became clear",
+              "item_url":"https://www.theguardian.com/us-news/2016/nov/12/suicide-prevention-hotline-record-calls-donald-trump-victory-lgbt?CMP=fb_newsbot",
+              "image_url":"https://media.guim.co.uk/802a0c4a563bc26e414bf62b4fc21ce5769dd3c5/0_346_5184_3110/1000.jpg",
+              "subtitle":"National Suicide Prevention Lifeline saw record 660 calls between 1am and 2am on Wednesday, amid particular concerns linked to LGBT community",
+              "buttons":[
+                {
+                  "type":"element_share",
+                  "title":null,
+                  "url":null,
+                  "payload":null
+                }
+              ]
+            },
+            {
+              "title":"‘It started getting scary’: how the mood changed at the Clinton election party",
+              "item_url":"https://www.theguardian.com/us-news/2016/nov/12/mood-hillary-clinton-election-party-changed-things-started-getting-crazy?CMP=fb_newsbot",
+              "image_url":"https://media.guim.co.uk/e0cdc1775108ef4cb06f1ad05806524ee1760a58/0_226_6145_3687/1000.jpg",
+              "subtitle":"The gathering at New York’s Javits convention centre began in a celebratory mood. Three women who were there recall what happened next",
+              "buttons":[
+                {
+                  "type":"element_share",
+                  "title":null,
+                  "url":null,
+                  "payload":null
+                }
+              ]
+            },
+            {
+              "title":"Nervous about a Trump presidency? Me too. But at least I've got legal weed",
+              "item_url":"https://www.theguardian.com/lifeandstyle/2016/nov/12/legal-marijuana-weed-high-times-2016-election?CMP=fb_newsbot",
+              "image_url":"https://media.guim.co.uk/5df8c63768f12807b338c433187a136acd213698/0_144_5200_3120/1000.jpg",
+              "subtitle":"Writer and cannabis consultant David Bienenstock reflects on a night of progressive marijuana legislation – in the face of regressive everything else",
+              "buttons":[
+                {
+                  "type":"element_share",
+                  "title":null,
+                  "url":null,
+                  "payload":null
+                }
+              ]
+            },
+            {
+              "title":"USA and Mexico soccer fans get on just fine, despite the awkward politics",
+              "item_url":"https://www.theguardian.com/football/2016/nov/12/usa-mexico-soccer-fans-donald-trump?CMP=fb_newsbot",
+              "image_url":"https://media.guim.co.uk/73eeba8441f00a4eb11fd2b3ae41817806fa8725/0_82_4446_2668/1000.jpg",
+              "subtitle":"Donald Trump’s election victory raised the prospect of added tension at Friday’s World Cup qualifier, but the game in Columbus went off without a hitch",
+              "buttons":[
+                {
+                  "type":"element_share",
+                  "title":null,
+                  "url":null,
+                  "payload":null
+                }
+              ]
+            },
+            {
+              "title":"Donald Trump appears to soften on Clinton emails and Obamacare",
+              "item_url":"https://www.theguardian.com/us-news/2016/nov/12/donald-trump-appears-to-soften-stance-on-range-of-pledges?CMP=fb_newsbot",
+              "image_url":"https://media.guim.co.uk/b250b829104b4f94af3a02129cf20a5c81654f96/0_0_5000_3000/1000.jpg",
+              "subtitle":"In first interview since winning election, Trump says he may not repeal Obamacare and Clinton’s prosecution not a priority",
+              "buttons":[
+                {
+                  "type":"element_share",
+                  "title":null,
+                  "url":null,
+                  "payload":null
+                }
+              ]
+            }
+          ],
+          "buttons":null
+        }
+      },
+      "metadata":null
+    },
+    "sender_action":null,
+    "notification_type":null
+  },
+  {
+    "recipient" : {
+      "id" : "headlines_test"
+    },
+    "message" : {
+      "text" : "Was this helpful?",
+      "attachment" : null,
+      "quick_replies" : [
+        {
+          "content_type" : "text",
+          "title" : "Yes",
+          "payload" : "yes",
+          "image_url" : null
+        },
+        {
+          "content_type" : "text",
+          "title" : "No",
+          "payload" : "no",
+          "image_url" : null
+        }
+      ],
+      "metadata" : null
+    },
+    "sender_action" : null,
+    "notification_type" : null
+  }
+]

--- a/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
@@ -20,7 +20,7 @@ object DummyCapi extends Capi {
   def getArticle(id: String): Future[Option[Content]] = Future.successful(None)
 
   private def getFromFile(`type`: String, edition: String, topic: Option[Topic]): Future[Seq[Content]] = {
-    val file = s"src/test/resources/capiResponses/${`type`}-${topic.map(_.getPath(edition).replace("/","-")).getOrElse(edition)}.json"
+    val file = s"src/test/resources/capiResponses/${`type`}-${topic.map(_.getQuery(edition).pathSegment.replace("/","-")).getOrElse(edition)}.json"
     val result = JsonHelpers.decodeFromFile[Seq[Content]](file)
 
     Future.successful(result)

--- a/src/test/scala/com/gu/facebook_news_bot/SearchTopicTest.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/SearchTopicTest.scala
@@ -1,0 +1,46 @@
+package com.gu.facebook_news_bot
+
+import com.gu.facebook_news_bot.services.SearchTopic
+import org.scalatest.{FunSpec, Matchers}
+
+class SearchTopicTest extends FunSpec with Matchers {
+  it("should extract Clinton but ignore 'News'") {
+    val topic = SearchTopic("What is your latest News on Clinton?")
+    topic.get.terms should be(List("Clinton"))
+  }
+
+  it("should extract microsoft, apple and twitter") {
+    val topic = SearchTopic("news on boring microsoft and tedious apple, oh and also twitter. I hate them all")
+    topic.get.terms should be(List("microsoft", "apple", "twitter"))
+  }
+
+  it("should extract clinton, trump, election") {
+    val topic = SearchTopic("did clinton or trump win the election?")
+    topic.get.terms should be(List("clinton","trump","election"))
+  }
+
+  it("should extract Obama, Trump") {
+    val topic = SearchTopic("Obama and Trump")
+    topic.get.terms should be(List("Obama", "Trump"))
+  }
+
+  it("should extract obama, trump, clinton") {
+    val topic = SearchTopic("obama, trump, clinton")
+    topic.get.terms should be(List("obama", "trump", "clinton"))
+  }
+
+  it("should extract Donald Trump as a single entity") {
+    val topic = SearchTopic("Donald Trump?")
+    topic.get.terms should be(List("Donald Trump"))
+  }
+
+  it("should extract election") {
+    val topic = SearchTopic("tell me about the election")
+    topic.get.terms should be(List("election"))
+  }
+
+  it("should extract boris") {
+    val topic = SearchTopic("boris")
+    topic.get.terms should be(List("boris"))
+  }
+}


### PR DESCRIPTION
### Existing functionality
We currently have a hardcoded set of topics, e.g. football, politics. These are mapped to specific sections/tags to ensure good results. If a user enters text containing a topic, the app returns a carousel with the links. If the user's input does not contain any of these hardcoded terms, it simply tells the user it doesn't understand.

### With this change
- If the user's input does not contain a topic then the app uses NLP to build a syntax tree from it (using http://stanfordnlp.github.io/CoreNLP/)
- Traverses the syntax tree looking for nouns, to build up a list of search terms.
- Uses CAPI's `q=` parameter to search for these terms. E.g. "Tell me about Obama and also Donald Trump" --> `/search?q=Obama+AND+%22Donald+Trump%22`
- The response to the user lists the terms it searched for, e.g. "I think you're asking me about obama and donald trump. Here are some articles that could be of interest." After the carousel, it asks "Was this helpful?" - and logs the user's response. It's good to show some humility with something with such variable results!

### Things to note:
- We already handle messages over 200 chars separately (by linking to readers' editor contact details), so it will never build large syntax trees. 
- Uses `order-by=relevance`, but then sorts the results by date to display the most recent. Otherwise the results can be very poor. It might be possible to tweak the [query decay params](https://github.com/guardian/content-api/blob/2cbab1c5ab45b36036866928f80cff48d686334e/concierge/src/main/scala/com.gu.contentapi.concierge/model/QueryGenerator.scala#L35) to get ES to do this for us, but we should not change existing behaviour in concierge.
- I've had to increase the ec2 from t2.micro to t2.small as the NLP library uses quite a lot of memory.

![picture 5](https://cloud.githubusercontent.com/assets/1513454/22830037/035e192e-ef9d-11e6-9e01-e26f3733db65.png)

![picture 6](https://cloud.githubusercontent.com/assets/1513454/22830045/0eefc27e-ef9d-11e6-91d4-9f831d6834a8.png)
