### PR TITLE
Only include stories published in last 24 hours in custom briefing

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
@@ -6,6 +6,7 @@ import com.gu.facebook_news_bot.services.{Capi, Topic}
 import com.gu.facebook_news_bot.state.StateHandler._
 import com.gu.facebook_news_bot.utils.FacebookMessageBuilder
 import com.gu.facebook_news_bot.utils.Loggers._
+import org.joda.time.{DateTime, DateTimeZone}
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -61,7 +62,14 @@ object CustomBriefing {
   }
 
   private def appendNextNonDup(next: Seq[Content]): Seq[Content] => Seq[Content] = { current =>
-    current ++ next.find(content => !current.exists(_.id == content.id))
+    current ++ next.find(content => isFresh(content) && !current.exists(_.id == content.id))
+  }
+
+  private def isFresh(content: Content): Boolean = {
+    content.webPublicationDate.exists { date =>
+      val pubDate = new DateTime(date.dateTime, DateTimeZone.UTC)
+      DateTime.now(DateTimeZone.UTC).minusHours(24).isBefore(pubDate)
+    }
   }
 
   def getVariant(edition: String) = s"custom-briefing-$edition"


### PR DESCRIPTION
Stories must have a webPublicationDate from the last 24 hours to be included in the custom briefing. Some sections keep the same article at the top for days