### PR TITLE
Add News Digest tile to Morning Briefing

### DIFF
--- a/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/briefing/CustomBriefing.scala
@@ -1,15 +1,13 @@
 package com.gu.facebook_news_bot.briefing
 
 import com.gu.contentapi.client.model.v1.Content
-import com.gu.facebook_news_bot.models.{Id, MessageToFacebook, User}
+import com.gu.facebook_news_bot.models.{MessageToFacebook, User}
 import com.gu.facebook_news_bot.services.{Capi, Topic}
-import com.gu.facebook_news_bot.state.StateHandler._
 import com.gu.facebook_news_bot.utils.FacebookMessageBuilder
-import com.gu.facebook_news_bot.utils.Loggers._
 import org.joda.time.{DateTime, DateTimeZone}
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 object CustomBriefing {
 
@@ -45,6 +43,7 @@ object CustomBriefing {
       }
 
       futureMaybeCarousel
+
     }.getOrElse(Future.successful(None))
   }
 

--- a/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
+++ b/src/main/scala/com/gu/facebook_news_bot/services/Capi.scala
@@ -32,6 +32,10 @@ object CapiImpl extends Capi {
   def getMostViewed(edition: String, topic: Option[Topic]): Future[Seq[Content]] =
     doQuery(edition, topic, _.showMostViewed(), _.mostViewed)
 
+  def getArticlesByTag(tag: String) = Future[Seq[Content]] = {
+    doSearchQuery(SearchQuery().tag(tag))
+  }
+
   def doQuery(edition: String, topic: Option[Topic], itemQueryModifier: ItemQuery => ItemQuery, getResults: (ItemResponse => Option[Seq[Content]])): Future[Seq[Content]] = {
     val query: ContentApiQuery = topic.map(_.getQuery(edition)).getOrElse(ItemQuery(edition))
     query match {

--- a/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
+++ b/src/test/scala/com/gu/facebook_news_bot/DummyCapi.scala
@@ -25,4 +25,8 @@ object DummyCapi extends Capi {
 
     Future.successful(result)
   }
+
+  def getArticlesByTag(tag: String): Future[Seq[Content]] = {
+    Future.successful(Nil)
+  }
 }


### PR DESCRIPTION
As an initial cut, we are delivering this to only UK readers. Clicking through on tile will take reader to Morning Briefing articles: https://www.theguardian.com/world/series/guardian-morning-briefing

If there is no fresh article, or the reader is outside UK, standard carousel is sent.

Once content in series is structured, plan is to give users option to consume content in bot.

Example seen on CODE: 
![screen shot 2017-03-06 at 18 13 17](https://cloud.githubusercontent.com/assets/14946184/23622964/9c16b820-0298-11e7-92ea-8b16b3e0136a.png)

Note: Height of tiles is different due to absence of button, but have decided not to introduce one until we've added the content in bot feature